### PR TITLE
Relative path license file checks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,7 @@
           </includes>
           <excludes>
             <exclude>**/target/**</exclude>
+            <exclude>**/.idea/**</exclude>
           </excludes>
           <mapping>
             <scala>JAVADOC_STYLE</scala>

--- a/tesla-polyglot-atom/pom.xml
+++ b/tesla-polyglot-atom/pom.xml
@@ -40,4 +40,16 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>io.tesla.maven.plugins</groupId>
+        <artifactId>tesla-license-plugin</artifactId>
+        <configuration>
+          <header>../license-header.txt</header>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>

--- a/tesla-polyglot-cli/pom.xml
+++ b/tesla-polyglot-cli/pom.xml
@@ -120,6 +120,15 @@
           </execution>
         </executions>
       </plugin>
+
+      <plugin>
+        <groupId>io.tesla.maven.plugins</groupId>
+        <artifactId>tesla-license-plugin</artifactId>
+        <configuration>
+          <header>../license-header.txt</header>
+        </configuration>
+      </plugin>
+
     </plugins>
     <pluginManagement>
       <plugins>

--- a/tesla-polyglot-clojure/pom.xml
+++ b/tesla-polyglot-clojure/pom.xml
@@ -71,6 +71,13 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>io.tesla.maven.plugins</groupId>
+        <artifactId>tesla-license-plugin</artifactId>
+        <configuration>
+          <header>../license-header.txt</header>
+        </configuration>
+      </plugin>
     </plugins>
     <pluginManagement>
       <plugins>

--- a/tesla-polyglot-common/pom.xml
+++ b/tesla-polyglot-common/pom.xml
@@ -34,4 +34,16 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>io.tesla.maven.plugins</groupId>
+        <artifactId>tesla-license-plugin</artifactId>
+        <configuration>
+          <header>../license-header.txt</header>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>

--- a/tesla-polyglot-gem/pom.xml
+++ b/tesla-polyglot-gem/pom.xml
@@ -157,6 +157,13 @@
           </filesets>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>io.tesla.maven.plugins</groupId>
+        <artifactId>tesla-license-plugin</artifactId>
+        <configuration>
+          <header>../license-header.txt</header>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/tesla-polyglot-groovy/pom.xml
+++ b/tesla-polyglot-groovy/pom.xml
@@ -59,4 +59,16 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>io.tesla.maven.plugins</groupId>
+        <artifactId>tesla-license-plugin</artifactId>
+        <configuration>
+          <header>../license-header.txt</header>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>

--- a/tesla-polyglot-maven-plugin/pom.xml
+++ b/tesla-polyglot-maven-plugin/pom.xml
@@ -35,4 +35,17 @@
         <version>${teslaVersion}</version>
       </dependency>
     </dependencies>
+
+    <build>
+      <plugins>
+        <plugin>
+          <groupId>io.tesla.maven.plugins</groupId>
+          <artifactId>tesla-license-plugin</artifactId>
+          <configuration>
+            <header>../license-header.txt</header>
+          </configuration>
+        </plugin>
+      </plugins>
+    </build>
+
 </project>

--- a/tesla-polyglot-ruby/pom.xml
+++ b/tesla-polyglot-ruby/pom.xml
@@ -54,4 +54,17 @@
       <artifactId>org.eclipse.sisu.inject</artifactId>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>io.tesla.maven.plugins</groupId>
+        <artifactId>tesla-license-plugin</artifactId>
+        <configuration>
+          <header>../license-header.txt</header>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>

--- a/tesla-polyglot-scala/pom.xml
+++ b/tesla-polyglot-scala/pom.xml
@@ -81,6 +81,13 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>io.tesla.maven.plugins</groupId>
+        <artifactId>tesla-license-plugin</artifactId>
+        <configuration>
+          <header>../license-header.txt</header>
+        </configuration>
+      </plugin>
     </plugins>
     <pluginManagement>
       <plugins>

--- a/tesla-polyglot-yaml/pom.xml
+++ b/tesla-polyglot-yaml/pom.xml
@@ -40,4 +40,16 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>io.tesla.maven.plugins</groupId>
+        <artifactId>tesla-license-plugin</artifactId>
+        <configuration>
+          <header>../license-header.txt</header>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>


### PR DESCRIPTION
Re-instated the ability to run module tests locally i.e. without building the entire project. This is achieved by re-declaring the location of the license file for each module.
