### PR TITLE
Eliminated scalaz-streams dependency

### DIFF
--- a/polyglot-scala/pom.xml
+++ b/polyglot-scala/pom.xml
@@ -52,7 +52,7 @@
 
     <dependency>
       <groupId>org.specs2</groupId>
-      <artifactId>specs2_2.10</artifactId>
+      <artifactId>specs2-junit_2.10</artifactId>
       <version>2.4.17</version>
       <scope>test</scope>
     </dependency>


### PR DESCRIPTION
The lack of a bintray resolver caused CI to fail. scalaz-streams isn't required and so a more specific dependency has now been declared.