### PR TITLE
Added note about cross-conversion options

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,11 +98,12 @@ mvn io.takari.polyglot:polyglot-translate-plugin:translate \
   -Dinput=pom.xml -Doutput=pom.{format}
 ```
 
-Where the supported formats are `rb`, `groovy`, `scala`, `yaml`, and `atom`.
+Where the supported formats are `rb`, `groovy`, `scala`, `yaml`, `atom` and of course `xml`.
 See [here](http://takari.io/2015/03/21/polyglot-maven.html) for more info.
+You can even convert back to `xml` or cross-convert between all supported formats.
 
 # Note of caution
 
 The whole interoperability story has not been worked out but we expect to sort this out very quickly now that Polyglot for Maven can be used easily.
 
-A pom.xml will currently not be installed or deployed except for the Ruby DSL but we will add this feature very shortly.
+A `pom.xml` will currently not be installed or deployed except for the Ruby DSL but we will add this feature very shortly.


### PR DESCRIPTION
We could even add a section that encourages people to experiment, because they can convert-back at any time, e.g. for deployment tasks.