### PR TITLE
Fix #50: add support for scope blocks

### DIFF
--- a/polyglot-groovy/src/main/java/org/sonatype/maven/polyglot/groovy/builder/ModelBuilder.java
+++ b/polyglot-groovy/src/main/java/org/sonatype/maven/polyglot/groovy/builder/ModelBuilder.java
@@ -1,17 +1,11 @@
 /**
- * Copyright (c) 2012 to original author or authors
+ * Copyright (c) 2012-2015 to original author or authors
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  */
 package org.sonatype.maven.polyglot.groovy.builder;
-
-import groovy.lang.Closure;
-import groovy.lang.GroovyObject;
-import groovy.lang.GroovyObjectSupport;
-import groovy.util.Factory;
-import groovy.util.FactoryBuilderSupport;
 
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
@@ -22,6 +16,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 
+import org.apache.maven.artifact.Artifact;
 import org.apache.maven.model.Activation;
 import org.apache.maven.model.Contributor;
 import org.apache.maven.model.Dependency;
@@ -68,7 +63,14 @@ import org.sonatype.maven.polyglot.groovy.builder.factory.PropertiesFactory;
 import org.sonatype.maven.polyglot.groovy.builder.factory.ReportSetsFactory;
 import org.sonatype.maven.polyglot.groovy.builder.factory.ReportingFactory;
 import org.sonatype.maven.polyglot.groovy.builder.factory.ReportsFactory;
+import org.sonatype.maven.polyglot.groovy.builder.factory.ScopeFactory;
 import org.sonatype.maven.polyglot.groovy.builder.factory.StringFactory;
+
+import groovy.lang.Closure;
+import groovy.lang.GroovyObject;
+import groovy.lang.GroovyObjectSupport;
+import groovy.util.Factory;
+import groovy.util.FactoryBuilderSupport;
 
 /**
  * Builds Maven {@link Model} instances.
@@ -81,11 +83,11 @@ import org.sonatype.maven.polyglot.groovy.builder.factory.StringFactory;
 public class ModelBuilder extends FactoryBuilderSupport {
   protected Logger log = LoggerFactory.getLogger(ModelBuilder.class);
 
-  private final Set<String> factoryNames = new HashSet<String>();
+  private final Set<String> factoryNames = new HashSet<>();
 
-  private final Set<Class> factoryTypes = new HashSet<Class>();
+  private final Set<Class> factoryTypes = new HashSet<>();
 
-  private final List<ExecuteTask> tasks = new ArrayList<ExecuteTask>();
+  private final List<ExecuteTask> tasks = new ArrayList<>();
 
   @Requirement
   private ExecuteManager executeManager;
@@ -142,7 +144,7 @@ public class ModelBuilder extends FactoryBuilderSupport {
     registerFactory(new ExecuteFactory());
     registerFactory(new ReportSetsFactory());
     registerFactory(new ReportsFactory());
-
+    
     registerFactory(new ReportingFactory());
     registerFactoriesFor(Reporting.class);
 
@@ -151,7 +153,12 @@ public class ModelBuilder extends FactoryBuilderSupport {
 
     registerFactory(new ModelFactory());
     registerFactoriesFor(Model.class);
-
+    registerFactory(new ScopeFactory(Artifact.SCOPE_COMPILE));
+    registerFactory(new ScopeFactory(Artifact.SCOPE_PROVIDED));
+    registerFactory(new ScopeFactory(Artifact.SCOPE_TEST));
+    registerFactory(new ScopeFactory(Artifact.SCOPE_RUNTIME));
+    registerFactory(new ScopeFactory(Artifact.SCOPE_SYSTEM));
+    registerFactory(new ScopeFactory(Artifact.SCOPE_IMPORT));
     registerChildFactory("dependency", Dependency.class);
     registerChildFactory("exclusion", Exclusion.class);
     registerChildFactory("extension", Extension.class);

--- a/polyglot-groovy/src/main/java/org/sonatype/maven/polyglot/groovy/builder/factory/ScopeFactory.java
+++ b/polyglot-groovy/src/main/java/org/sonatype/maven/polyglot/groovy/builder/factory/ScopeFactory.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2015 to original author or authors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.sonatype.maven.polyglot.groovy.builder.factory;
+
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.model.Dependency;
+
+import groovy.util.FactoryBuilderSupport;
+
+/**
+ * Builds dependency scope nodes. If a {@link Dependency} scope is not set,
+ * the scope of its parent Node will be assigned.
+ * 
+ * @author Fred Bricon
+ */
+public class ScopeFactory extends ListFactory {
+
+	private Map<Object, List<Dependency>> scopeHierarchy = new IdentityHashMap<>();
+	
+	private String scope;
+	
+	public ScopeFactory(String scope) {
+		//scope nodes are prefixed with $ because import (scope) is a keyword.
+		super("$"+scope);
+		this.scope = scope;
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public void setParent(FactoryBuilderSupport builder, Object dependencies, Object scopeBlock) {
+		if (dependencies instanceof List && scopeBlock instanceof List) {
+			scopeHierarchy.put(scopeBlock, (List<Dependency>)dependencies);
+		}
+	}
+
+	@Override
+	public void setChild(FactoryBuilderSupport builder, Object scopeBlock, Object child) {
+		if (child instanceof Dependency) {
+			Dependency dep = (Dependency) child;
+			if (!Artifact.SCOPE_COMPILE.equals(scope) && dep.getScope() == null) {
+				dep.setScope(scope);
+			}//XXX Should we throw an exception if dependency scope != current block scope?
+			scopeHierarchy.get(scopeBlock).add(dep);
+		}
+	}
+}

--- a/polyglot-groovy/src/test/groovy/org/sonatype/maven/polyglot/groovy/GroovyModelTestSupport.groovy
+++ b/polyglot-groovy/src/test/groovy/org/sonatype/maven/polyglot/groovy/GroovyModelTestSupport.groovy
@@ -7,23 +7,23 @@
  */
 package org.sonatype.maven.polyglot.groovy
 
+import static org.junit.Assert.*
+
 import javax.xml.parsers.DocumentBuilder
 import javax.xml.parsers.DocumentBuilderFactory
+
 import org.apache.maven.model.Model
 import org.apache.maven.model.io.DefaultModelWriter
-import org.sonatype.maven.polyglot.groovy.Dom2Groovy
+import org.codehaus.plexus.PlexusTestCase
 import org.w3c.dom.Document
 import org.xml.sax.InputSource
-import static org.junit.Assert.*
-import org.sonatype.maven.polyglot.groovy.Dom2Groovy
-import org.codehaus.plexus.PlexusTestCase
 
 /**
  * Support for model tests.
  *
  * @author <a href="mailto:jason@planet57.com">Jason Dillon</a>
  */
-public class GroovyModelTestSupport
+public abstract class GroovyModelTestSupport
     extends PlexusTestCase
 {
     protected String load(final String name) {

--- a/polyglot-groovy/src/test/groovy/org/sonatype/maven/polyglot/groovy/builder/ModelBuilderTest.groovy
+++ b/polyglot-groovy/src/test/groovy/org/sonatype/maven/polyglot/groovy/builder/ModelBuilderTest.groovy
@@ -7,9 +7,10 @@
  */
 package org.sonatype.maven.polyglot.groovy.builder
 
+import static org.junit.Assert.*
+
 import org.junit.Before
 import org.junit.Test
-import static org.junit.Assert.*
 import org.sonatype.maven.polyglot.groovy.GroovyModelTestSupport
 
 /**
@@ -262,4 +263,129 @@ public class ModelBuilderTest
         assertEquals("a", e[1].groupId)
         assertEquals("b", e[1].artifactId)
     }
+	
+	@Test
+	void testBuildWithScopeBlocks() {
+		def model = builder.project {
+			dependencies {
+				$test {
+					dependency 't:a:1'
+					dependency 't:b:2:compile'
+				}
+				$provided {
+					dependency 'p:a:1'
+					dependency 'p:b:2:system'
+				}
+				$runtime {
+					dependency 'r:a:1'
+					dependency 'r:b:2:test'
+				}
+				$compile {
+					dependency 'c:a:1'
+					dependency 'c:b:2:test'
+				}
+				dependency 'a:b:c'
+				$system {
+					dependency 's:a:1'
+					dependency 's:b:2'
+				}
+				$import {
+					dependency 'i:a:1'
+					dependency 'i:b:2'
+				}
+			}
+		}
+
+		assertNotNull(model)
+		assertNotNull(model.dependencies)
+		assertEquals(13, model.dependencies.size())
+
+		def d 
+		int i = 0
+		//From test block
+		d = model.dependencies[i++]
+		assertEquals('t', d.groupId)
+		assertEquals('a', d.artifactId)
+		assertEquals('1', d.version)
+		assertEquals('test', d.scope)
+		
+		d = model.dependencies[i++]
+		assertEquals('t', d.groupId)
+		assertEquals('b', d.artifactId)
+		assertEquals('2', d.version)
+		assertEquals('compile', d.scope)
+		
+		//From provided block
+		d = model.dependencies[i++]
+		assertEquals('p', d.groupId)
+		assertEquals('a', d.artifactId)
+		assertEquals('1', d.version)
+		assertEquals('provided', d.scope)
+		
+		d = model.dependencies[i++]
+		assertEquals('p', d.groupId)
+		assertEquals('b', d.artifactId)
+		assertEquals('2', d.version)
+		assertEquals('system', d.scope)
+		
+		//From runtime block
+		d = model.dependencies[i++]
+		assertEquals('r', d.groupId)
+		assertEquals('a', d.artifactId)
+		assertEquals('1', d.version)
+		assertEquals('runtime', d.scope)
+		
+		d = model.dependencies[i++]
+		assertEquals('r', d.groupId)
+		assertEquals('b', d.artifactId)
+		assertEquals('2', d.version)
+		assertEquals('test', d.scope)
+		
+		//From compile block
+		d = model.dependencies[i++]
+		assertEquals('c', d.groupId)
+		assertEquals('a', d.artifactId)
+		assertEquals('1', d.version)
+		assertNull(d.scope)
+		
+		d = model.dependencies[i++]
+		assertEquals('c', d.groupId)
+		assertEquals('b', d.artifactId)
+		assertEquals('2', d.version)
+		assertEquals('test', d.scope)
+		
+		//No block
+		d = model.dependencies[i++]
+		assertEquals('a', d.groupId)
+		assertEquals('b', d.artifactId)
+		assertEquals('c', d.version)
+		assertNull(d.scope)
+		
+		
+		//From system block
+		d = model.dependencies[i++]
+		assertEquals('s', d.groupId)
+		assertEquals('a', d.artifactId)
+		assertEquals('1', d.version)
+		assertEquals('system', d.scope)
+		
+		d = model.dependencies[i++]
+		assertEquals('s', d.groupId)
+		assertEquals('b', d.artifactId)
+		assertEquals('2', d.version)
+		assertEquals('system', d.scope)
+		
+		//From import block
+		d = model.dependencies[i++]
+		assertEquals('i', d.groupId)
+		assertEquals('a', d.artifactId)
+		assertEquals('1', d.version)
+		assertEquals('import', d.scope)
+		
+		d = model.dependencies[i++]
+		assertEquals('i', d.groupId)
+		assertEquals('b', d.artifactId)
+		assertEquals('2', d.version)
+		assertEquals('import', d.scope)
+	}
 }


### PR DESCRIPTION
This new change introduces scope blocks, that make it cleaner to list/group dependencies, like:

```
project {
   modelVersion '4.0.0'
   groupId 'foo.bar'
   artifactId 'example'
   version '0.0.1-SNAPSHOT'
   dependencies {
      $test { //junit and mockito get the test scope
          dependency 'junit:junit:4.12'
          dependency 'org.mockito:mockito-core:1.10.19'
      }
      $compile {//list all compile scoped dependencies here
          dependency 'foo:bar:x.y.z'
          ...
       }
       dependency 'a:b:1.0.0' //also compile  scope
        ...
    } 
 }
```

The following scoped blocks are supported:
- $compile {...}
- $import  {...}
- $test    {...}
- $provided{...}
- $runtime  {...}
- $system  {...}

In the current implementation, dependencies can overwrite the outer scope like

```
$provided {
    'foo:bar:x.y.z:test' //will have the test scope
}
```

Signed-off-by: Fred Bricon fbricon@gmail.com
