### PR TITLE
Enable polyglot-xml to use both '.xml' and '.xml41' file extensions.

### DIFF
--- a/polyglot-common/src/main/java/org/sonatype/maven/polyglot/PolyglotModelManager.java
+++ b/polyglot-common/src/main/java/org/sonatype/maven/polyglot/PolyglotModelManager.java
@@ -8,6 +8,9 @@
 package org.sonatype.maven.polyglot;
 
 import java.io.File;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 
@@ -38,9 +41,22 @@ public class PolyglotModelManager implements ModelLocator {
     assert mapping != null;
     mappings.add(mapping);
   }
+  
+  public List<Mapping> getSortedMappings() {
+    List<Mapping> sortedMappings = new ArrayList<Mapping>(mappings);
+    
+    Collections.sort(sortedMappings, new Comparator<Mapping>() {
+	  @Override
+	  public int compare(Mapping o1, Mapping o2) {
+		return Float.compare(o1.getPriority(), o2.getPriority());
+	  }
+	});
+	
+	return sortedMappings;
+  }
 
-  public ModelReader getReaderFor(final Map<String, ?> options) {
-    for (Mapping mapping : mappings) {
+  public ModelReader getReaderFor(final Map<String, ?> options) {	 
+    for (Mapping mapping : getSortedMappings()) {
       if (mapping.accept(options)) {
         return mapping.getReader();
       }
@@ -50,7 +66,7 @@ public class PolyglotModelManager implements ModelLocator {
   }
 
   public ModelWriter getWriterFor(final Map<String, ?> options) {
-    for (Mapping mapping : mappings) {
+    for (Mapping mapping : getSortedMappings()) {
       if (mapping.accept(options)) {
         return mapping.getWriter();
       }
@@ -93,7 +109,7 @@ public class PolyglotModelManager implements ModelLocator {
   }
 
   public String getFlavourFor(final Map<String, ?> options) {
-    for (Mapping mapping : mappings) {
+    for (Mapping mapping : getSortedMappings()) {
       if (mapping.accept(options)) {
         return mapping.getFlavour();
       }

--- a/polyglot-xml/README.md
+++ b/polyglot-xml/README.md
@@ -7,7 +7,7 @@ This is achieved by mean of using xml attributes for:
 
 Please note that not all properties of plugins are defined as attributes. Please refer to  */polyglot-xml/src/test/resources/pom/pom_maven_v4_1.xml* for example and use XSD file from */polyglot-xml/src/main/resources/xsd/4.1.0* folder.
 
-In order to differentiate between default POM XML syntax and this custom dialect it is required to use some non-default file extension since *pom.xml* is already associated with default syntax. That is why filees processed by this extension should have `.xml41` file extension.
+Files processed by `polygloy-xml` can have `.xml41` or `.xml` file extensions. When working with `.xml` files `polyglot-xml` runs before standard xml systax to check whether file contains default syntax or not. For default syntax execution is delegated to default Maven parser. But when `polygloy-xml` detects that it can process file it does this instead of default Maven xml parser.
 
 Short example of supported format:
 ```xml
@@ -66,3 +66,4 @@ Use simple Maven Plugin that will help you convert any existing
 mvn io.takari.polyglot:polyglot-translate-plugin:translate \
   -Dinput=pom.xml -Doutput=pom.xml41
 ```
+Please note that in this case `pom.xml` uses default Maven xml syntax and `pom.xml41` will use syntax defined in `polyglot-xml`.


### PR DESCRIPTION
Enable polyglot-xml to use both '.xml' and '.xml41' file extensions. This has required changes in PolyglotModelManager.java to sort available mappings before evaluating them. We need to be able to plug polyglot-xml before standard xml mapping.