### PR TITLE
Added alternative translate-project goal

### DIFF
--- a/polyglot-translate-plugin/src/main/java/io/takari/maven/polyglot/TranslateProjectMojo.java
+++ b/polyglot-translate-plugin/src/main/java/io/takari/maven/polyglot/TranslateProjectMojo.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2012, 2016 to original author or authors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package io.takari.maven.polyglot;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Component;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
+import org.sonatype.maven.polyglot.TeslaModelTranslator;
+
+/**
+ * Polgyglot model translator Mojo.
+ * 
+ */
+@Mojo(name = "translate-project")
+public class TranslateProjectMojo extends AbstractMojo {
+
+	@Component
+	private TeslaModelTranslator translator;
+
+	@Parameter(required = true, property = "input")
+	private String input;
+
+	@Parameter(required = true, property = "output")
+	private String output;
+
+	@Parameter(readonly = true, required = true, defaultValue = "${project}")
+	private MavenProject mavenProject;
+
+	@Override
+	public void execute() throws MojoExecutionException, MojoFailureException {
+		try {
+			File inputFile = new File(mavenProject.getBasedir(), input);
+			File outputFile = new File(mavenProject.getBasedir(), output);
+			getLog().info(String.format("Translating %s -> %s", inputFile, outputFile));
+			translator.translate(inputFile, outputFile);
+		} catch (IOException e) {
+			throw new MojoExecutionException(String.format("Error translating %s -> %s", input, output), e);
+		}
+	}
+}


### PR DESCRIPTION
The motivation behind this second goal is to avoid inconveniences with the 'translate' goal, which works on the complete reactor but does not handle errors well.

With this goal, the user can control in detail which projects should be translated and how errors are handled with the known mvn commandline options (e.g.: -N, -pl, -am, -amd, -fae)
