### PR TITLE
translate-plugin: Added missing plugin dependency

### DIFF
--- a/polyglot-translate-plugin/pom.xml
+++ b/polyglot-translate-plugin/pom.xml
@@ -18,6 +18,13 @@
   <packaging>takari-maven-plugin</packaging>
 
   <dependencies>
+    <!-- This dep was set to provided in parent pom, but when used as Maven plugin, it is essential -->
+    <dependency>
+      <groupId>org.codehaus.plexus</groupId>
+      <artifactId>plexus-utils</artifactId>
+      <version>3.0.24</version>
+      <scope>runtime</scope>
+    </dependency>
     <dependency>
       <groupId>io.takari.polyglot</groupId>
       <artifactId>polyglot-common</artifactId>


### PR DESCRIPTION
This dependency is explicitly needed, as we mark it as provided in the parent pom and this results in an much older and incompatible version resolved at runtime.

This should also really fix #96, which was closed too early.

It would be great to have a new release as soon as possible, as the fixed issues renderes the plugin usage very inconvenient, esp. when executed without a project.