### PR TITLE
Improved handling of string with special characters in scala writer

### DIFF
--- a/polyglot-scala/src/main/scala/org/sonatype/maven/polyglot/scala/ScalaModelWriter.scala
+++ b/polyglot-scala/src/main/scala/org/sonatype/maven/polyglot/scala/ScalaModelWriter.scala
@@ -25,6 +25,14 @@ object ScalaPrettyPrinter extends PrettyPrinter {
 
   // Various doc functions that enhance doc construction for our domain.
 
+  /**
+   * Surround `d` with a tripple-double-quote if it contains a '"' or '\n' or '\n', else with a double-quote.
+   * This is named `dquotes` to shadow `quotes(d: Doc): Doc` from PrettyPrinterBase.
+   */
+  def dquotes(d: String): Doc =
+    if (d.matches(".*[\"\\n\\r].*")) surround(d, dquote <> dquote <> dquote)
+    else surround(d, dquote)
+
   def assignString(label: String, value: String): Doc = label <+> equal <+> dquotes(value)
 
   def assign(label: String, value: Doc): Doc = label <+> equal <+> value

--- a/polyglot-scala/src/test/resources/pom-strings.scala
+++ b/polyglot-scala/src/test/resources/pom-strings.scala
@@ -1,0 +1,8 @@
+import org.sonatype.maven.polyglot.scala.model._
+import scala.collection.immutable.Seq
+
+Model(
+  "io.tesla.polyglot" % "tesla-polyglot" % "0.0.1-SNAPSHOT",
+  name = """Multiline
+string"""
+)

--- a/polyglot-scala/src/test/scala/org/sonatype/maven/polyglot/scala/ScalaModelReaderWriterSpec.scala
+++ b/polyglot-scala/src/test/scala/org/sonatype/maven/polyglot/scala/ScalaModelReaderWriterSpec.scala
@@ -86,6 +86,9 @@ class ScalaModelReaderWriterSpec extends Specification with AfterExample {
     "read, write and compare a minimal pom" in {
       readWriteAndCompare("minimal-pom.scala")
     }
+    "read, write and compare a pom with multi-line strings" in {
+      readWriteAndCompare("pom-strings.scala")
+    }
     "read, write and compare a full pom" in {
       readWriteAndCompare("maximum-props-pom.scala")
     }


### PR DESCRIPTION
This fixes #100.

In essence, when a string contains a `"`, `\n`, or `\r`, it will be surrounded with tripple double quotes (`"""`).

The solutions is a bit "hacky", as I shadow the equally named `dquotes` function of PrettyPrinterBase (from kiama) with a version containing the logic. I'm open for a better solution.