### PR TITLE
polyglot-scala: Scala syntax friendly include preprocessor

### DIFF
--- a/polyglot-scala/src/main/scala/org/sonatype/maven/polyglot/scala/ScalaModelReader.scala
+++ b/polyglot-scala/src/main/scala/org/sonatype/maven/polyglot/scala/ScalaModelReader.scala
@@ -188,13 +188,9 @@ class ScalaModelReader @Inject()(executeManager: ExecuteManager) extends ModelRe
     /*
    * This is a preprocesor that can include files by requesting them from the given resolvers.
    * 
-   * This preprocessor support lines starting with: `#include` and `//##include`.
-   * The former is the legacy version.
-   * The latter variant is preferred, as it keeps the Scala source file syntactically correct 
-   * and this enables editors and IDEs to parse, format and highlight the file correctly.
+   * This preprocessor support lines starting with: `//#include`.
    * 
-   * @example #include file-name.scala
-   * @example //##include file-name.scala
+   * @example //#include file-name.scala
    *
    * Note that it is *not* recursive. Included files cannot have includes
    */
@@ -207,7 +203,7 @@ class ScalaModelReader @Inject()(executeManager: ExecuteManager) extends ModelRe
       def apply(code: String, maxDepth: Int): String = {
         val lines = code.lines map { line: String =>
           val tokens = line.trim.split(' ')
-          if (tokens.length == 2 && (tokens(0).equals("#include") || tokens(0).equals("//##include"))) {
+          if (tokens.length == 2 && tokens(0).equals("//#include")) {
             val path = tokens(1)
             resolvers find { resolver: Resolver =>
               resolver.resolvable(path)

--- a/polyglot-scala/src/main/scala/org/sonatype/maven/polyglot/scala/ScalaModelReader.scala
+++ b/polyglot-scala/src/main/scala/org/sonatype/maven/polyglot/scala/ScalaModelReader.scala
@@ -257,7 +257,10 @@ class ScalaModelReader @Inject()(executeManager: ExecuteManager) extends ModelRe
         // versions of CompilerException make those information available, we should map them here (instead of zeros).
         // Currently, the information is only available as text in the exeception message.
         // Parsing it would be wasteful and possibly unstable.
-        throw new ModelParseException("Cannot compile pom file: " + sourceFile, 0, 0, e)
+        throw new ModelParseException(
+          "Cannot compile pom file: " + sourceFile +
+            "\nYou can run 'mvn -Deval.debug' to see the resolved scala file.",
+          0, 0, e)
       case e: Throwable =>
         throw new ModelParseException("Could not process pom file: " + sourceFile, 0, 0, e)
     }

--- a/polyglot-scala/src/main/scala/org/sonatype/maven/polyglot/scala/ScalaModelReader.scala
+++ b/polyglot-scala/src/main/scala/org/sonatype/maven/polyglot/scala/ScalaModelReader.scala
@@ -187,7 +187,7 @@ class ScalaModelReader @Inject()(executeManager: ExecuteManager) extends ModelRe
     /*
    * This is a preprocesor that can include files by requesting them from the given resolvers.
    * 
-   * This preprocessor support lines starting with: `#include` and `//#include`.
+   * This preprocessor support lines starting with: `#include` and `//##include`.
    * The former is the legacy version.
    * The latter variant is preferred, as it keeps the Scala source file syntactically correct 
    * and this enables editors and IDEs to parse, format and highlight the file correctly.

--- a/polyglot-scala/src/test/resources/include.scala
+++ b/polyglot-scala/src/test/resources/include.scala
@@ -1,0 +1,4 @@
+import org.sonatype.maven.polyglot.scala.model._
+import scala.collection.immutable.Seq
+
+val includedVersion = "1.0.0"

--- a/polyglot-scala/src/test/resources/pom-with-include.scala
+++ b/polyglot-scala/src/test/resources/pom-with-include.scala
@@ -1,0 +1,9 @@
+import org.sonatype.maven.polyglot.scala.model._
+import scala.collection.immutable.Seq
+
+//#include include.scala
+
+Model(
+  "io.tesla.polyglot" % "tesla-polyglot" % includedVersion,
+  name = "Include Test"
+)

--- a/polyglot-scala/src/test/scala/org/sonatype/maven/polyglot/scala/ScalaModelReaderWriterSpec.scala
+++ b/polyglot-scala/src/test/scala/org/sonatype/maven/polyglot/scala/ScalaModelReaderWriterSpec.scala
@@ -217,5 +217,10 @@ class ScalaModelReaderWriterSpec extends Specification with AfterExample {
                    |  )
                    |)""".stripMargin
     }
+
+    "read a pom with include properly" in {
+      val model = readScalaModel("pom-with-include.scala")
+      model.getVersion must_== "1.0.0"
+    }
   }
 }


### PR DESCRIPTION
This change adds an alternative preprocessor directive to the scala dialect.

In addition to `#include <file>`, now also `//##include <file>` is supported.
The motivation behind this is, to improve the editing experience. The latter added version produces syntax-correct scala files, which in turn improves editors and IDEs, e.g. parsing, formatting and highlighting. The former version does not.

The unusual long prefix `//##` was choosen, to avoid confusion with a possibly commented out include (e.g. `// #include`).

Also, this change adds a hint how to debug the `pom.scala` script to the error message in case of a compile error.