### PR TITLE
Use Travis CI for continuous integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,14 @@ sudo: false
 
 language: java
 
+# TODO: support also Java7, but current maven plugins do not like it
+# TODO: alternatively add java7 bootclasspath to compile
 jdk:
-  - oraclejdk7
   - oraclejdk8
-  - openjdk7
 
 before_script: 
 - mvn -N io.takari:maven:wrapper -Dmaven=3.5.0
 
 script: 
-- mvnw clean source:jar javadoc:jar install
+- ./mvnw clean source:jar javadoc:jar install
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ jdk:
 - oraclejdk8
 
 before_script: 
-- mvn -N io.takari:maven:wrapper -Dmaven=3.5.0
+- mvn -N io.takari:maven:0.4.3:wrapper -Dmaven=3.5.0
 
 script: 
 - ./mvnw clean package source:jar javadoc:jar install

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,10 @@ language: java
 # TODO: support also Java7, but current maven plugins do not like it
 # TODO: alternatively add java7 bootclasspath to compile
 jdk:
-  - oraclejdk8
+- oraclejdk8
 
 before_script: 
 - mvn -N io.takari:maven:wrapper -Dmaven=3.5.0
 
 script: 
-- ./mvnw clean source:jar javadoc:jar install
-
+- ./mvnw clean package source:jar javadoc:jar install

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+sudo: false
+
+language: java
+
+jdk:
+  - oraclejdk7
+  - oraclejdk8
+  - openjdk7
+
+before_script: 
+- mvn -N io.takari:maven:wrapper -Dmaven=3.5.0
+
+script: 
+- mvnw clean install
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,5 @@ before_script:
 - mvn -N io.takari:maven:wrapper -Dmaven=3.5.0
 
 script: 
-- mvnw clean install
+- mvnw clean source:jar javadoc:jar install
 

--- a/README.md
+++ b/README.md
@@ -3,10 +3,9 @@
 [Polyglot for Maven](http://github.com/takari/polyglot-maven/) is a set of extensions for `Maven 3.3.1+` that
 allows the POM model to be written in dialects other than XML. Several of the dialects also allow inlined plugins:
 the Ruby, Groovy and Scala dialects allow this.
-
 [![License](https://img.shields.io/badge/License-EPL%201.0-red.svg)](https://opensource.org/licenses/EPL-1.0)
-
 [![Maven Central](https://img.shields.io/maven-central/v/io.takari.polyglot/polyglot.svg?label=Maven%20Central)](http://search.maven.org/#search%7Cgav%7C1%7Cg%3A%22io.takari.polyglot%22%20AND%20a%3A%22polyglot%22)
+[![Build Status](https://travis-ci.org/takari/polyglot-maven.svg?branch=master)](https://travis-ci.org/takari/polyglot-maven)
 
 Here's an example POM written in the Ruby dialect:
 


### PR DESCRIPTION
This branch prepares the source tree to be build with Travis CI.

Besides a merge, to benefit from it, the following tasks need to be done:

* Enable Travis / create Travis account for organization takari
* Activate travis builds for polyglot-maven project
* optional: Register pull request hook to have travis builds and GitHub integration for pull requests
