### PR TITLE
polyglot-scala: Use zinc server if running

### DIFF
--- a/polyglot-scala/pom.xml
+++ b/polyglot-scala/pom.xml
@@ -108,6 +108,7 @@
               </args>
               <checkMultipleScalaVersions>false</checkMultipleScalaVersions>
               <recompileMode>incremental</recompileMode>
+              <useZincServer>true</useZincServer>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
If a running zinc is detected, it is used for compilation. This significantly improves compile times, as it avoid a scalac cold start.

If no running zinc can be detected, the build falls back to normal incremental compilation. So no downsides for those not running zinc server.

In case you want to use zinc, you can start it with: `zinc -start -nailed -server localhost`
