### PR TITLE
polyglot-scala: Support more valid XML element name chars in dynamic Config

### DIFF
--- a/polyglot-scala/src/test/scala/org/sonatype/maven/polyglot/scala/ConfigSpec.scala
+++ b/polyglot-scala/src/test/scala/org/sonatype/maven/polyglot/scala/ConfigSpec.scala
@@ -103,5 +103,29 @@ class ConfigSpec extends Specification {
       e(2)._1 must_== "@key4"
       e(2)._2.get.asInstanceOf[String] must_== "attrValue4"
     }
+
+
+    // the attribute marker
+    s"should permit `@` char in element name via dynamic apply" in {
+      Config(`@Key@` = "value").elements.head._1 must_== "@Key$at"
+    }
+
+    // this one should always work, as _ is also valid in scala
+    s"should permit `_` char in element name via dynamic apply" in {
+      Config(`_Key_` = "value").elements.head._1 must_== "_Key_"
+    }
+
+    s"should permit `:` char in element name via dynamic apply" in {
+      Config(`:Key:` = "value").elements.head._1 must_== ":Key:"
+    }
+
+    s"should permit `.` char in element name via dynamic apply" in {
+      Config(`.Key.` = "value").elements.head._1 must_== "$u002EKey."
+    }
+
+    s"should permit `-` char in element name via dynamic apply" in {
+      Config(`-Key-` = "value").elements.head._1 must_== "$minusKey-"
+    }
+
   }
 }


### PR DESCRIPTION
The convenient dynamic apply of `Config` companion object has currently some technical limitations which result in mangled parameter names. When used without further processing (as it is currently the case), not all valid element names (in terms of XML element spec) can be specified, e.g. the minus ("-") is a valid character in XML element names, but not in Scala methods names.

To get the following model (config of bundle-maven-plugin, XML notation):
```xml
<configuration>
  <instructions>
    <Bundle-Name>Test bundle</Bundle-Name>
  </instructions>
</configuration>
```

I want to write:
```scala
configuration = Config(
  instructions = Config(
    `Bundle-Name` = "Test bundle"
  )
)
```

But this currently doesn't work. It results in:
```xml
<configuration>
  <instructions>
    <Bundle$minusName>Test bundle</Bundle$minusName>
  </instructions>
</configuration>
```

So, one has to fall back to the class constructor of the Config class.
```scala
configuration = Config(
  instructions = new Config(immutable.Seq(
    "Bundle-Name" -> Some("Test bundle")
  ))
)
```

This PR tries to fix that.

The list of possibly supportable characters is not complete yet, but it's a start for the most common cases. I added a TODO note linking the XML spec.

I need to figure out how to programmatically create test cases with specs2. Any hint is welcome.

EDIT: added better motivation