### PR TITLE
polyglot-scala: Added convenience methods to Dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ at an easier glance.
 
 ## Version 0.3.1 or higher - Upcoming
 
+- polyglot-scala: Convenience methods for `Dependency` (`classifier`, `intransitive`, `%` (scope))
+  - see https://github.com/takari/polyglot-maven/pull/156
+  - contributed by Tobias Roeser https://github.com/lefou
+
 User community contriubtions welcome...
 
 ## Version 0.3.0 - 2018-03-07

--- a/polyglot-scala/src/main/scala/org/sonatype/maven/polyglot/scala/model/Dependency.scala
+++ b/polyglot-scala/src/main/scala/org/sonatype/maven/polyglot/scala/model/Dependency.scala
@@ -10,14 +10,29 @@ package org.sonatype.maven.polyglot.scala.model
 import scala.collection.immutable
 
 class Dependency(
-                  val gav: Gav,
-                  val `type`: String,
-                  val classifier: Option[String],
-                  val scope: Option[String],
-                  val systemPath: Option[String],
-                  val exclusions: immutable.Seq[GroupArtifactId],
-                  val optional: Boolean
-                  )
+    val gav: Gav,
+    val `type`: String,
+    val classifier: Option[String],
+    val scope: Option[String],
+    val systemPath: Option[String],
+    val exclusions: immutable.Seq[GroupArtifactId],
+    val optional: Boolean) {
+
+  def copy(
+    gav: Gav = gav,
+    `type`: String = `type`,
+    classifier: String = this.classifier.orNull,
+    scope: String = this.scope.orNull,
+    systemPath: String = this.systemPath.orNull,
+    exclusions: immutable.Seq[GroupArtifactId] = exclusions,
+    optional: Boolean = optional): Dependency =
+    new Dependency(gav, `type`, Option(classifier), Option(scope), Option(systemPath), exclusions, optional)
+
+  def classifier(classifier: String): Dependency = copy(classifier = classifier)
+
+  def %(scope: String): Dependency = copy(scope = Option(scope).filter(s => !s.trim().isEmpty()).orNull)
+
+}
 
 object Dependency {
   def apply(

--- a/polyglot-scala/src/main/scala/org/sonatype/maven/polyglot/scala/model/Dependency.scala
+++ b/polyglot-scala/src/main/scala/org/sonatype/maven/polyglot/scala/model/Dependency.scala
@@ -18,6 +18,9 @@ class Dependency(
     val exclusions: immutable.Seq[GroupArtifactId],
     val optional: Boolean) {
 
+  /**
+   * Returns a derived dependency with the given new properties.
+   */
   def copy(
     gav: Gav = gav,
     `type`: String = `type`,
@@ -28,8 +31,20 @@ class Dependency(
     optional: Boolean = optional): Dependency =
     new Dependency(gav, `type`, Option(classifier), Option(scope), Option(systemPath), exclusions, optional)
 
+  /**
+   * Returns a derived dependencies with the given classifier.
+   */
   def classifier(classifier: String): Dependency = copy(classifier = classifier)
 
+  /**
+   * Returns a derived dependency without it's transitive dependencies.
+   * This is internally done by setting an universal exclusion (`"*" % "*"`).
+   */
+  def intransitive: Dependency = copy(exclusions = immutable.Seq("*" % "*"))
+  
+  /**
+   * Returns a derived dependency with the given scope.
+   */
   def %(scope: String): Dependency = copy(scope = Option(scope).filter(s => !s.trim().isEmpty()).orNull)
 
 }


### PR DESCRIPTION
This allows us to use a Dependency the same way as a Gav.

Example: declare a scope:

```
dep % "test"
```

Also changing the classifier is easier now.