### PR TITLE
polyglot-scala: Added default value for pom property modelversion (4.0.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,11 @@ at an easier glance.
 
 ## Version 0.3.1 or higher - Upcoming
 
-User community contriubtions welcome...
-
 - polyglot-scala: Added default value for pom property modelversion (4.0.0)
   - see https://github.com/takari/polyglot-maven/pull/158
   - contributed by Tobias Roeser https://github.com/lefou
+
+User community contributions welcome...
 
 ## Version 0.3.0 - 2018-03-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ at an easier glance.
 
 User community contriubtions welcome...
 
+- polyglot-scala: Added default value for pom property modelversion (4.0.0)
+  - see https://github.com/takari/polyglot-maven/pull/158
+  - contributed by Tobias Roeser https://github.com/lefou
+
 ## Version 0.3.0 - 2018-03-07
 
 - Updated Scala version

--- a/polyglot-scala/src/main/scala/org/sonatype/maven/polyglot/scala/model/Model.scala
+++ b/polyglot-scala/src/main/scala/org/sonatype/maven/polyglot/scala/model/Model.scala
@@ -97,7 +97,7 @@ object Model {
              licenses: immutable.Seq[License] = Nil,
              mailingLists: immutable.Seq[MailingList] = Nil,
              modelEncoding: String = "UTF-8",
-             modelVersion: String = null,
+             modelVersion: String = "4.0.0",
              modules: immutable.Seq[String] = Nil,
              name: String = null,
              organization: Organization = null,

--- a/polyglot-scala/src/main/scala/org/sonatype/maven/polyglot/scala/model/ScalaModel.scala
+++ b/polyglot-scala/src/main/scala/org/sonatype/maven/polyglot/scala/model/ScalaModel.scala
@@ -106,7 +106,7 @@ object ScalaModel {
              licenses: immutable.Seq[License] = Nil,
              mailingLists: immutable.Seq[MailingList] = Nil,
              modelEncoding: String = "UTF-8",
-             modelVersion: String = null,
+             modelVersion: String = "4.0.0",
              modules: immutable.Seq[String] = Nil,
              name: String = null,
              organization: Organization = null,


### PR DESCRIPTION
It is more than expected, that this version will not change in the near future.