### PR TITLE
fixes #118

### DIFF
--- a/polyglot-yaml/src/main/java/org/sonatype/maven/polyglot/yaml/ModelConstructor.java
+++ b/polyglot-yaml/src/main/java/org/sonatype/maven/polyglot/yaml/ModelConstructor.java
@@ -221,7 +221,7 @@ public final class ModelConstructor extends Constructor {
 
     private void toAttribute(Xpp3Dom parent, String key, Object value) {
       if (value instanceof List || value instanceof Map) {
-        throw new YAMLException("Attribute's value have to be a plain string. Node: " + parent);
+        throw new YAMLException("Attribute's value has to be a plain string. Node: " + parent);
       }
 
       parent.setAttribute(key, value.toString());

--- a/polyglot-yaml/src/main/java/org/sonatype/maven/polyglot/yaml/ModelConstructor.java
+++ b/polyglot-yaml/src/main/java/org/sonatype/maven/polyglot/yaml/ModelConstructor.java
@@ -146,12 +146,19 @@ public final class ModelConstructor extends Constructor {
   }
 
   private class ConstructXpp3Dom implements Construct {
+    private static final String ATTRIBUTE_PREFIX = "attr/";
+
     private Xpp3Dom toDom(Xpp3Dom parent, Map<Object, Object> map) {
 
       for (Map.Entry<Object, Object> entry : map.entrySet()) {
         String key = entry.getKey().toString();
         Object entryValue = entry.getValue();
         Xpp3Dom child = new Xpp3Dom(key);
+
+        if (key.startsWith(ATTRIBUTE_PREFIX)) {
+          toAttribute(parent, key.replace(ATTRIBUTE_PREFIX, ""), entryValue);
+          continue;
+        }
 
         // lists need the insertion of intermediate XML DOM nodes which hold the actual values
         if (entryValue instanceof List && !((List) entryValue).isEmpty()) {
@@ -210,6 +217,14 @@ public final class ModelConstructor extends Constructor {
           parent.addChild(itemNode);
         }
       }
+    }
+
+    private void toAttribute(Xpp3Dom parent, String key, Object value) {
+      if (value instanceof List || value instanceof Map) {
+        throw new YAMLException("Attribute's value have to be a plain string. Node: " + parent);
+      }
+
+      parent.setAttribute(key, value.toString());
     }
 
     public Object construct(Node node) {

--- a/polyglot-yaml/src/main/java/org/sonatype/maven/polyglot/yaml/ModelRepresenter.java
+++ b/polyglot-yaml/src/main/java/org/sonatype/maven/polyglot/yaml/ModelRepresenter.java
@@ -88,6 +88,7 @@ class ModelRepresenter extends Representer {
 
 
   private class RepresentXpp3Dom implements Represent {
+    private static final String ATTRIBUTE_PREFIX = "attr/";
 
     public Node representData(Object data) {
       return representMapping(Tag.MAP, toMap((Xpp3Dom) data), null);
@@ -129,6 +130,10 @@ class ModelRepresenter extends Representer {
         map.put(childName, childValue);
       }
 
+      for (String attrName : node.getAttributeNames()) {
+        map.put(ATTRIBUTE_PREFIX + attrName, node.getAttribute(attrName));
+      }
+
       return map;
     }
 
@@ -165,7 +170,7 @@ class ModelRepresenter extends Representer {
           "artifactId",
           "version",
           "packaging",
-          
+
           "name",
           "description",
           "url",
@@ -178,7 +183,7 @@ class ModelRepresenter extends Representer {
           "scm",
           "issueManagement",
           "ciManagement",
-          
+
           "properties",
           "prerequisites",
           "modules",

--- a/polyglot-yaml/src/test/java/org/sonatype/maven/polyglot/yaml/ElementsWithAttributesTest.java
+++ b/polyglot-yaml/src/test/java/org/sonatype/maven/polyglot/yaml/ElementsWithAttributesTest.java
@@ -1,0 +1,18 @@
+package org.sonatype.maven.polyglot.yaml;
+
+import org.apache.maven.model.Model;
+import org.codehaus.plexus.util.xml.Xpp3Dom;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.sonatype.maven.polyglot.yaml.Util.getModel;
+
+public class ElementsWithAttributesTest {
+  @Test
+  public void testCompactExample() throws Exception {
+    Model model = getModel("elements-with-attributes-example.yaml");
+    Xpp3Dom configuration = (Xpp3Dom) model.getBuild().getPlugins().get(0).getExecutions().get(0).getConfiguration();
+
+    assertEquals("Hello from polyglot-yaml", configuration.getChild("target").getChild("echo").getAttribute("message"));
+  }
+}

--- a/polyglot-yaml/src/test/java/org/sonatype/maven/polyglot/yaml/Util.java
+++ b/polyglot-yaml/src/test/java/org/sonatype/maven/polyglot/yaml/Util.java
@@ -7,6 +7,8 @@
  */
 package org.sonatype.maven.polyglot.yaml;
 
+import org.apache.maven.model.Model;
+
 import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -46,5 +48,11 @@ public class Util {
     } catch (IOException e) {
       throw new RuntimeException(e);
     }
+  }
+
+  public static Model getModel(String fileName) throws Exception {
+    YamlModelReader modelReader = new YamlModelReader();
+    InputStream input = Thread.currentThread().getContextClassLoader().getResourceAsStream(fileName);
+    return modelReader.read(input, null);
   }
 }

--- a/polyglot-yaml/src/test/resources/elements-with-attributes-example.yaml
+++ b/polyglot-yaml/src/test/resources/elements-with-attributes-example.yaml
@@ -1,0 +1,14 @@
+# AKA issue-118
+
+modelVersion: 4.0.0
+parent: org.apache:apache:17
+id: org.yaml:snakeyaml:1.30
+name: SnakeYAML
+
+build:
+    plugins:
+    - id: org.apache.maven.plugins:maven-antrun-plugin:1.8
+      executions:
+        - configuration:
+            target:
+              echo: {attr/message: Hello from polyglot-yaml}


### PR DESCRIPTION
 Hi there. This MR fixes issue #118. The idea is to store attributes with a prepended prefix, for example, "attr/". It's safe in the sense there won't be collisions with existing names of elements or attributes. Also, when pom.yaml is being parsed and converted to pom all prefixes are being removed and valid pom representation is being generated. The only tricky thing is documenting of such specifics, I think.
 
I would like to use a pretty "@" char instead of "attr/", but for some reasons, authors of snake-yaml disallow yaml tokens starting with the ampersand.   