### PR TITLE
FIX issue-99, exclude pomFile property from serializing

### DIFF
--- a/polyglot-yaml/src/main/java/org/sonatype/maven/polyglot/yaml/ModelRepresenter.java
+++ b/polyglot-yaml/src/main/java/org/sonatype/maven/polyglot/yaml/ModelRepresenter.java
@@ -46,6 +46,11 @@ class ModelRepresenter extends Representer {
 
   protected NodeTuple representJavaBeanProperty(Object javaBean, Property property,
                                                 Object propertyValue, Tag customTag) {
+    if (property != null && property.getName().equals("pomFile")) {
+      // "pomFile" is not a part of POM http://maven.apache.org/xsd/maven-4.0.0.xsd
+      return null;
+    }
+
     if (propertyValue == null) return null;
     if (propertyValue instanceof Map) {
       Map map = (Map) propertyValue;


### PR DESCRIPTION
This funny bug demonstrates devaluation of an idea of java-bean in java development. One day the work with reference to pom file was required, and so `setPomFile`, `getPomFile` methods were added. `pomFile` is not a Model property, however yaml-snake still trying to work with it and builds an invalid document. This fix excludes the quasi-property `pomFile` from serialization.