### PR TITLE
Use alternative target path for compiled pom model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ at an easier glance.
 - polyglot-scala: Added default value for pom property modelversion (4.0.0)
   - see https://github.com/takari/polyglot-maven/pull/158
   - contributed by Tobias Roeser https://github.com/lefou
+- polyglot-scala: Made output dir to pom.scala files compilation configurable via system property `polyglot.scala.outputdir`
+  - see https://github.com/takari/polyglot-maven/pull/165
+  - contributed by Tobias Roeser https://github.com/lefou
 
 User community contributions welcome...
 

--- a/polyglot-scala/src/main/scala/org/sonatype/maven/polyglot/scala/ScalaModelReader.scala
+++ b/polyglot-scala/src/main/scala/org/sonatype/maven/polyglot/scala/ScalaModelReader.scala
@@ -179,9 +179,10 @@ class ScalaModelReader @Inject() (executeManager: ExecuteManager) extends ModelR
   }
 
   private def locateEvalPomFile(options: util.Map[String, _]): File = {
+    val targetDir = Option(System.getProperty("polyglot.scala.outputdir")).getOrElse("target")
     val source = PolyglotModelUtil.getLocation(options)
     val binVersion = _root_.scala.util.Properties.versionNumberString.split("[.]").take(2).mkString(".")
-    val evalTarget = new File(new File(source).getParent, ".mvn.polyglot" + File.separator + "scalamodel_" + binVersion)
+    val evalTarget = new File(new File(source).getParent, targetDir + File.separator + "scalamodel_" + binVersion)
     evalTarget.mkdirs()
     new File(evalTarget, "pom.scala")
   }

--- a/polyglot-scala/src/main/scala/org/sonatype/maven/polyglot/scala/ScalaModelReader.scala
+++ b/polyglot-scala/src/main/scala/org/sonatype/maven/polyglot/scala/ScalaModelReader.scala
@@ -181,7 +181,7 @@ class ScalaModelReader @Inject() (executeManager: ExecuteManager) extends ModelR
   private def locateEvalPomFile(options: util.Map[String, _]): File = {
     val source = PolyglotModelUtil.getLocation(options)
     val binVersion = _root_.scala.util.Properties.versionNumberString.split("[.]").take(2).mkString(".")
-    val evalTarget = new File(new File(source).getParent, "target" + File.separator + "scalamodel_" + binVersion)
+    val evalTarget = new File(new File(source).getParent, ".mvn.polyglot" + File.separator + "scalamodel_" + binVersion)
     evalTarget.mkdirs()
     new File(evalTarget, "pom.scala")
   }


### PR DESCRIPTION
With this change, we no longer store the compiled class files from `pom.scala` under `target`, but use a dedicated `.mvn.polyglot` dir. 

Motivation: Typical repeated maven runs include the `clean` goal, which removes the `target` dir. This means, we need to re-compile all `pom.scala` files in the next run, which cost's a lot of time.
