### PR TITLE
Issue #191 replace hard-coded versions in test files

### DIFF
--- a/polyglot-kotlin/pom.xml
+++ b/polyglot-kotlin/pom.xml
@@ -64,7 +64,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <kotlin.version>1.3.41</kotlin.version>
+    <kotlin.version>1.3.50</kotlin.version>
     <commons-lang3.version>3.8.1</commons-lang3.version>
     <skipTests>false</skipTests>
     <invoker.skip>${skipTests}</invoker.skip>

--- a/polyglot-kotlin/pom.xml
+++ b/polyglot-kotlin/pom.xml
@@ -60,11 +60,6 @@
       <artifactId>logback-classic</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>com.google.code.maven-replacer-plugin</groupId>
-      <artifactId>replacer</artifactId>
-      <version>1.5.3</version>
-    </dependency>
   </dependencies>
 
   <properties>

--- a/polyglot-kotlin/pom.xml
+++ b/polyglot-kotlin/pom.xml
@@ -45,6 +45,11 @@
 
     <!-- Test -->
     <dependency>
+      <groupId>io.takari.polyglot</groupId>
+      <artifactId>polyglot-maven-plugin</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <version>3.11.1</version>

--- a/polyglot-kotlin/pom.xml
+++ b/polyglot-kotlin/pom.xml
@@ -55,6 +55,11 @@
       <artifactId>logback-classic</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.google.code.maven-replacer-plugin</groupId>
+      <artifactId>replacer</artifactId>
+      <version>1.5.3</version>
+    </dependency>
   </dependencies>
 
   <properties>
@@ -71,7 +76,7 @@
     <plugins>
       <plugin>
         <artifactId>maven-invoker-plugin</artifactId>
-        <version>3.1.0</version>
+        <version>3.2.0</version>
         <configuration>
           <failIfNoProjects>true</failIfNoProjects>
           <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
@@ -115,7 +120,28 @@
           </execution>
         </executions>
       </plugin>
-    </plugins>
+      <plugin>
+        <groupId>com.google.code.maven-replacer-plugin</groupId>
+        <artifactId>replacer</artifactId>
+        <version>1.5.3</version>
+        <executions>
+          <execution>
+            <phase>test-compile</phase>
+            <goals>
+              <goal>replace</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <basedir>${project.build.testOutputDirectory}</basedir>
+          <includes>**/pom.xml</includes>
+          <delimiters>{{*}}</delimiters>
+          <regex>false</regex>
+          <token>takari-polyglot-version</token>
+          <value>${project.version}</value>
+        </configuration>
+      </plugin>
+</plugins>
   </build>
 
 </project>

--- a/polyglot-kotlin/pom.xml
+++ b/polyglot-kotlin/pom.xml
@@ -135,7 +135,7 @@
         <configuration>
           <basedir>${project.build.testOutputDirectory}</basedir>
           <includes>**/pom.xml</includes>
-          <delimiters>{{*}}</delimiters>
+          <delimiters>@{*}</delimiters>
           <regex>false</regex>
           <token>takari-polyglot-version</token>
           <value>${project.version}</value>

--- a/polyglot-kotlin/src/main/kotlin/org/sonatype/maven/polyglot/kotlin/engine/ScriptDefinition.kt
+++ b/polyglot-kotlin/src/main/kotlin/org/sonatype/maven/polyglot/kotlin/engine/ScriptDefinition.kt
@@ -7,29 +7,27 @@ import org.apache.maven.project.MavenProject
 import org.apache.maven.settings.Settings
 import org.codehaus.plexus.util.xml.Xpp3DomBuilder
 import org.sonatype.maven.polyglot.execute.ExecuteContext
-import java.io.File
-import kotlin.script.experimental.api.*
+import kotlin.script.experimental.api.ScriptAcceptedLocation
+import kotlin.script.experimental.api.ScriptCompilationConfiguration
+import kotlin.script.experimental.api.acceptedLocations
+import kotlin.script.experimental.api.ide
 import kotlin.script.experimental.jvm.dependenciesFromClassContext
 import kotlin.script.experimental.jvm.jvm
-import kotlin.script.experimental.jvm.updateClasspath
 
 object ScriptDefinition : ScriptCompilationConfiguration(
-    {
-        jvm {
-            // workaround for https://github.com/JetBrains/kotlin/commit/67ad3773de2b12f7e1d29e00151b997a4f6373ba#r34443917
-            // will be fixed in Kotlin 1.3.50+
-            updateClasspath(listOf(File(PomKtsScript::class.java.protectionDomain.codeSource.location.toURI())))
-            dependenciesFromClassContext(PomKtsScript::class, "polyglot-kotlin") // needed for DSL
-            dependenciesFromClassContext(ExecuteContext::class, "polyglot-common") // needed for executing tasks
-            dependenciesFromClassContext(Model::class, "maven-model") // needed for maven model
-            dependenciesFromClassContext(MavenProject::class, "maven-core") // needed for maven project/session
-            dependenciesFromClassContext(Artifact::class, "maven-artifact") // needed for maven artifacts
-            dependenciesFromClassContext(Settings::class, "maven-settings") // needed for accessing settings
-            dependenciesFromClassContext(Xpp3DomBuilder::class, "plexus-utils") // needed for Xpp3DomBuilder
-            dependenciesFromClassContext(Log::class, "maven-plugin-api") // Needed for writing to the Maven build log
+        {
+            jvm {
+                dependenciesFromClassContext(PomKtsScript::class, "polyglot-kotlin") // needed for DSL
+                dependenciesFromClassContext(ExecuteContext::class, "polyglot-common") // needed for executing tasks
+                dependenciesFromClassContext(Model::class, "maven-model") // needed for maven model
+                dependenciesFromClassContext(MavenProject::class, "maven-core") // needed for maven project/session
+                dependenciesFromClassContext(Artifact::class, "maven-artifact") // needed for maven artifacts
+                dependenciesFromClassContext(Settings::class, "maven-settings") // needed for accessing settings
+                dependenciesFromClassContext(Xpp3DomBuilder::class, "plexus-utils") // needed for Xpp3DomBuilder
+                dependenciesFromClassContext(Log::class, "maven-plugin-api") // Needed for writing to the Maven build log
+            }
+            ide {
+                acceptedLocations(ScriptAcceptedLocation.Everywhere)
+            }
         }
-        ide {
-            acceptedLocations(ScriptAcceptedLocation.Everywhere)
-        }
-    }
 )

--- a/polyglot-kotlin/src/main/kotlin/org/sonatype/maven/polyglot/kotlin/engine/ScriptDefinition.kt
+++ b/polyglot-kotlin/src/main/kotlin/org/sonatype/maven/polyglot/kotlin/engine/ScriptDefinition.kt
@@ -1,5 +1,6 @@
 package org.sonatype.maven.polyglot.kotlin.engine
 
+import org.apache.maven.artifact.Artifact
 import org.apache.maven.model.Model
 import org.apache.maven.plugin.logging.Log
 import org.apache.maven.project.MavenProject
@@ -22,6 +23,7 @@ object ScriptDefinition : ScriptCompilationConfiguration(
             dependenciesFromClassContext(ExecuteContext::class, "polyglot-common") // needed for executing tasks
             dependenciesFromClassContext(Model::class, "maven-model") // needed for maven model
             dependenciesFromClassContext(MavenProject::class, "maven-core") // needed for maven project/session
+            dependenciesFromClassContext(Artifact::class, "maven-artifact") // needed for maven artifacts
             dependenciesFromClassContext(Settings::class, "maven-settings") // needed for accessing settings
             dependenciesFromClassContext(Xpp3DomBuilder::class, "plexus-utils") // needed for Xpp3DomBuilder
             dependenciesFromClassContext(Log::class, "maven-plugin-api") // Needed for writing to the Maven build log

--- a/polyglot-kotlin/src/test/kotlin/org/sonatype/maven/polyglot/kotlin/testing/AbstractModelTestCase.kt
+++ b/polyglot-kotlin/src/test/kotlin/org/sonatype/maven/polyglot/kotlin/testing/AbstractModelTestCase.kt
@@ -18,7 +18,7 @@ abstract class AbstractModelTestCase(testName: String) : PlexusTestCase() {
     }
 
     protected val testBasePath: String = testName.removePrefix("test#").replace('#', '/')
-    private val testResources: File = File("src/test/resources")
+    private val testResources: File = File("target/test-classes")
     private val testOutput: File = File("target/test-output")
 
     private val kotlinModelWriter: ModelWriter = lookup(ModelWriter::class.java, "kotlin")

--- a/polyglot-kotlin/src/test/resources/convert/kotlin-to-xml/variation-1/pom.xml
+++ b/polyglot-kotlin/src/test/resources/convert/kotlin-to-xml/variation-1/pom.xml
@@ -298,7 +298,7 @@
       <plugin>
         <groupId>io.takari.polyglot</groupId>
         <artifactId>polyglot-maven-plugin</artifactId>
-        <version>0.4.4-SNAPSHOT</version>
+        <version>{{takari-polyglot-version}}</version>
         <executions>
           <execution>
             <id>hello</id>
@@ -404,7 +404,7 @@
           <dependency>
             <groupId>io.takari.polyglot</groupId>
             <artifactId>polyglot-kotlin</artifactId>
-            <version>0.4.4-SNAPSHOT</version>
+            <version>{{takari-polyglot-version}}</version>
           </dependency>
         </dependencies>
         <inherited>false</inherited>

--- a/polyglot-kotlin/src/test/resources/convert/kotlin-to-xml/variation-1/pom.xml
+++ b/polyglot-kotlin/src/test/resources/convert/kotlin-to-xml/variation-1/pom.xml
@@ -298,7 +298,7 @@
       <plugin>
         <groupId>io.takari.polyglot</groupId>
         <artifactId>polyglot-maven-plugin</artifactId>
-        <version>{{takari-polyglot-version}}</version>
+        <version>@{takari-polyglot-version}</version>
         <executions>
           <execution>
             <id>hello</id>
@@ -404,7 +404,7 @@
           <dependency>
             <groupId>io.takari.polyglot</groupId>
             <artifactId>polyglot-kotlin</artifactId>
-            <version>{{takari-polyglot-version}}</version>
+            <version>@{takari-polyglot-version}</version>
           </dependency>
         </dependencies>
         <inherited>false</inherited>

--- a/polyglot-kotlin/src/test/resources/convert/kotlin-to-xml/variation-2/pom.xml
+++ b/polyglot-kotlin/src/test/resources/convert/kotlin-to-xml/variation-2/pom.xml
@@ -289,7 +289,7 @@
       <plugin>
         <groupId>io.takari.polyglot</groupId>
         <artifactId>polyglot-maven-plugin</artifactId>
-        <version>0.4.4-SNAPSHOT</version>
+        <version>{{takari-polyglot-version}}</version>
         <executions>
           <execution>
             <id>hello</id>
@@ -395,7 +395,7 @@
           <dependency>
             <groupId>io.takari.polyglot</groupId>
             <artifactId>polyglot-kotlin</artifactId>
-            <version>0.4.4-SNAPSHOT</version>
+            <version>{{takari-polyglot-version}}</version>
           </dependency>
         </dependencies>
         <inherited>false</inherited>

--- a/polyglot-kotlin/src/test/resources/convert/kotlin-to-xml/variation-2/pom.xml
+++ b/polyglot-kotlin/src/test/resources/convert/kotlin-to-xml/variation-2/pom.xml
@@ -289,7 +289,7 @@
       <plugin>
         <groupId>io.takari.polyglot</groupId>
         <artifactId>polyglot-maven-plugin</artifactId>
-        <version>{{takari-polyglot-version}}</version>
+        <version>@{takari-polyglot-version}</version>
         <executions>
           <execution>
             <id>hello</id>
@@ -395,7 +395,7 @@
           <dependency>
             <groupId>io.takari.polyglot</groupId>
             <artifactId>polyglot-kotlin</artifactId>
-            <version>{{takari-polyglot-version}}</version>
+            <version>@{takari-polyglot-version}</version>
           </dependency>
         </dependencies>
         <inherited>false</inherited>

--- a/polyglot-kotlin/src/test/resources/example/pom.xml
+++ b/polyglot-kotlin/src/test/resources/example/pom.xml
@@ -86,7 +86,7 @@
       <plugin>
         <groupId>io.takari.polyglot</groupId>
         <artifactId>polyglot-maven-plugin</artifactId>
-        <version>{{takari-polyglot-version}}</version>
+        <version>@{takari-polyglot-version}</version>
         <executions>
           <execution>
             <id>hello</id>
@@ -115,7 +115,7 @@
           <dependency>
             <groupId>io.takari.polyglot</groupId>
             <artifactId>polyglot-kotlin</artifactId>
-            <version>{{takari-polyglot-version}}</version>
+            <version>@{takari-polyglot-version}</version>
           </dependency>
         </dependencies>
         <inherited>false</inherited>

--- a/polyglot-kotlin/src/test/resources/example/pom.xml
+++ b/polyglot-kotlin/src/test/resources/example/pom.xml
@@ -86,7 +86,7 @@
       <plugin>
         <groupId>io.takari.polyglot</groupId>
         <artifactId>polyglot-maven-plugin</artifactId>
-        <version>0.4.4-SNAPSHOT</version>
+        <version>{{takari-polyglot-version}}</version>
         <executions>
           <execution>
             <id>hello</id>
@@ -115,7 +115,7 @@
           <dependency>
             <groupId>io.takari.polyglot</groupId>
             <artifactId>polyglot-kotlin</artifactId>
-            <version>0.4.4-SNAPSHOT</version>
+            <version>{{takari-polyglot-version}}</version>
           </dependency>
         </dependencies>
         <inherited>false</inherited>

--- a/polyglot-kotlin/src/test/resources/unit-tests/execute/variation-1/pom.xml
+++ b/polyglot-kotlin/src/test/resources/unit-tests/execute/variation-1/pom.xml
@@ -7,7 +7,7 @@
       <plugin>
         <groupId>io.takari.polyglot</groupId>
         <artifactId>polyglot-maven-plugin</artifactId>
-        <version>{{takari-polyglot-version}}</version>
+        <version>@{takari-polyglot-version}</version>
         <executions>
           <execution>
             <id>hello</id>
@@ -25,7 +25,7 @@
           <dependency>
             <groupId>io.takari.polyglot</groupId>
             <artifactId>polyglot-kotlin</artifactId>
-            <version>{{takari-polyglot-version}}</version>
+            <version>@{takari-polyglot-version}</version>
           </dependency>
         </dependencies>
         <inherited>false</inherited>

--- a/polyglot-kotlin/src/test/resources/unit-tests/execute/variation-1/pom.xml
+++ b/polyglot-kotlin/src/test/resources/unit-tests/execute/variation-1/pom.xml
@@ -7,7 +7,7 @@
       <plugin>
         <groupId>io.takari.polyglot</groupId>
         <artifactId>polyglot-maven-plugin</artifactId>
-        <version>0.4.4-SNAPSHOT</version>
+        <version>{{takari-polyglot-version}}</version>
         <executions>
           <execution>
             <id>hello</id>
@@ -25,7 +25,7 @@
           <dependency>
             <groupId>io.takari.polyglot</groupId>
             <artifactId>polyglot-kotlin</artifactId>
-            <version>0.4.4-SNAPSHOT</version>
+            <version>{{takari-polyglot-version}}</version>
           </dependency>
         </dependencies>
         <inherited>false</inherited>

--- a/polyglot-kotlin/src/test/resources/unit-tests/execute/variation-2/pom.xml
+++ b/polyglot-kotlin/src/test/resources/unit-tests/execute/variation-2/pom.xml
@@ -11,7 +11,7 @@
           <plugin>
             <groupId>io.takari.polyglot</groupId>
             <artifactId>polyglot-maven-plugin</artifactId>
-            <version>0.4.4-SNAPSHOT</version>
+            <version>{{takari-polyglot-version}}</version>
             <executions>
               <execution>
                 <id>hello</id>
@@ -29,7 +29,7 @@
               <dependency>
                 <groupId>io.takari.polyglot</groupId>
                 <artifactId>polyglot-kotlin</artifactId>
-                <version>0.4.4-SNAPSHOT</version>
+                <version>{{takari-polyglot-version}}</version>
               </dependency>
             </dependencies>
             <inherited>false</inherited>

--- a/polyglot-kotlin/src/test/resources/unit-tests/execute/variation-2/pom.xml
+++ b/polyglot-kotlin/src/test/resources/unit-tests/execute/variation-2/pom.xml
@@ -11,7 +11,7 @@
           <plugin>
             <groupId>io.takari.polyglot</groupId>
             <artifactId>polyglot-maven-plugin</artifactId>
-            <version>{{takari-polyglot-version}}</version>
+            <version>@{takari-polyglot-version}</version>
             <executions>
               <execution>
                 <id>hello</id>
@@ -29,7 +29,7 @@
               <dependency>
                 <groupId>io.takari.polyglot</groupId>
                 <artifactId>polyglot-kotlin</artifactId>
-                <version>{{takari-polyglot-version}}</version>
+                <version>@{takari-polyglot-version}</version>
               </dependency>
             </dependencies>
             <inherited>false</inherited>

--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,11 @@
       </dependency>
       <dependency>
         <groupId>io.takari.polyglot</groupId>
+        <artifactId>polyglot-maven-plugin</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.takari.polyglot</groupId>
         <artifactId>polyglot-ruby</artifactId>
         <version>${project.version}</version>
       </dependency>


### PR DESCRIPTION
Fixes #191 
I also upgraded Kotlin to 1.3.50 and removed a now obsolete workaround.
There was also a bug where the basedir didn't always point to the actual Maven project dir, this was happening when the project was imported using IntelliJ IDEA. It should now always work correctly :)