### PR TITLE
Fix #201 Add kotlin specific source directories

### DIFF
--- a/polyglot-kotlin/src/main/kotlin/org/sonatype/maven/polyglot/kotlin/dsl/Build.kt
+++ b/polyglot-kotlin/src/main/kotlin/org/sonatype/maven/polyglot/kotlin/dsl/Build.kt
@@ -3,6 +3,11 @@ package org.sonatype.maven.polyglot.kotlin.dsl
 @PomDsl
 open class Build : org.apache.maven.model.Build(), Cloneable {
 
+    init {
+        sourceDirectory = "src/main/kotlin"
+        testSourceDirectory = "src/test/kotlin"
+    }
+
     @PomDsl
     fun sourceDirectory(sourceDirectory: String): Build {
         this.sourceDirectory = sourceDirectory

--- a/polyglot-kotlin/src/test/resources/convert/kotlin-to-xml/variation-1/pom.xml
+++ b/polyglot-kotlin/src/test/resources/convert/kotlin-to-xml/variation-1/pom.xml
@@ -167,6 +167,8 @@
     </pluginRepository>
   </pluginRepositories>
   <build>
+    <sourceDirectory>src/main/kotlin</sourceDirectory>
+    <testSourceDirectory>src/test/kotlin</testSourceDirectory>
     <extensions>
       <extension>
         <groupId>com.example.extensions</groupId>

--- a/polyglot-kotlin/src/test/resources/convert/kotlin-to-xml/variation-2/pom.xml
+++ b/polyglot-kotlin/src/test/resources/convert/kotlin-to-xml/variation-2/pom.xml
@@ -158,6 +158,8 @@
     </pluginRepository>
   </pluginRepositories>
   <build>
+    <sourceDirectory>src/main/kotlin</sourceDirectory>
+    <testSourceDirectory>src/test/kotlin</testSourceDirectory>
     <extensions>
       <extension>
         <groupId>com.example.extensions</groupId>

--- a/polyglot-kotlin/src/test/resources/unit-tests/build/variation-3/pom.xml
+++ b/polyglot-kotlin/src/test/resources/unit-tests/build/variation-3/pom.xml
@@ -3,6 +3,8 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
   <build>
+    <sourceDirectory>src/main/kotlin</sourceDirectory>
+    <testSourceDirectory>src/test/kotlin</testSourceDirectory>
     <pluginManagement>
       <plugins>
         <plugin>

--- a/polyglot-kotlin/src/test/resources/unit-tests/build/variation-4/pom.xml
+++ b/polyglot-kotlin/src/test/resources/unit-tests/build/variation-4/pom.xml
@@ -3,6 +3,8 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
   <build>
+    <sourceDirectory>src/main/kotlin</sourceDirectory>
+    <testSourceDirectory>src/test/kotlin</testSourceDirectory>
     <pluginManagement>
       <plugins>
         <plugin>

--- a/polyglot-kotlin/src/test/resources/unit-tests/build/variation-5/pom.xml
+++ b/polyglot-kotlin/src/test/resources/unit-tests/build/variation-5/pom.xml
@@ -3,6 +3,8 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
   <build>
+    <sourceDirectory>src/main/kotlin</sourceDirectory>
+    <testSourceDirectory>src/test/kotlin</testSourceDirectory>
     <pluginManagement>
       <plugins>
         <plugin>

--- a/polyglot-kotlin/src/test/resources/unit-tests/build/variation-6/pom.xml
+++ b/polyglot-kotlin/src/test/resources/unit-tests/build/variation-6/pom.xml
@@ -3,6 +3,8 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
   <build>
+    <sourceDirectory>src/main/kotlin</sourceDirectory>
+    <testSourceDirectory>src/test/kotlin</testSourceDirectory>
     <pluginManagement>
       <plugins>
         <plugin>

--- a/polyglot-kotlin/src/test/resources/unit-tests/execute/variation-1/pom.xml
+++ b/polyglot-kotlin/src/test/resources/unit-tests/execute/variation-1/pom.xml
@@ -3,6 +3,8 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
   <build>
+    <sourceDirectory>src/main/kotlin</sourceDirectory>
+    <testSourceDirectory>src/test/kotlin</testSourceDirectory>
     <plugins>
       <plugin>
         <groupId>io.takari.polyglot</groupId>

--- a/polyglot-kotlin/src/test/resources/unit-tests/execute/variation-2/pom.xml
+++ b/polyglot-kotlin/src/test/resources/unit-tests/execute/variation-2/pom.xml
@@ -2,7 +2,10 @@
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
-  <build />
+  <build>
+    <sourceDirectory>src/main/kotlin</sourceDirectory>
+    <testSourceDirectory>src/test/kotlin</testSourceDirectory>
+  </build>
   <profiles>
     <profile>
       <id>coverage</id>


### PR DESCRIPTION
This PR will set `sourceDirectory` and `testSourceDirectory` to the default locations `src/main/kotlin` and `src/test/kotlin` (Convention over Configuration)