### PR TITLE
Kotlin 1.4.0 upgrade

### DIFF
--- a/polyglot-kotlin/pom.xml
+++ b/polyglot-kotlin/pom.xml
@@ -39,7 +39,7 @@
     </dependency>
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
-      <artifactId>kotlin-scripting-jvm-host-embeddable</artifactId>
+      <artifactId>kotlin-scripting-jvm-host</artifactId>
       <version>${kotlin.version}</version>
     </dependency>
 
@@ -64,7 +64,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <kotlin.version>1.3.60</kotlin.version>
+    <kotlin.version>1.4.0</kotlin.version>
     <commons-lang3.version>3.8.1</commons-lang3.version>
     <skipTests>false</skipTests>
     <invoker.skip>${skipTests}</invoker.skip>


### PR DESCRIPTION
This pull request upgrades the polyglot-kotlin extension to use Kotlin 1.4.0 which was released on August 17. This fixes an issue that arises with projects using the polyglot-kotlin extension with Kotlin 1.4.0. When these projects attempt to compile their own kotlin source code, the kotlin maven compiler plugin gets the following exception:

```
java.lang.NoSuchMethodError: 'kotlin.sequences.Sequence kotlin.sequences.SequencesKt.flatMapIterable(kotlin.sequences.Sequence, kotlin.jvm.functions.Function1)'
```

While debugging, I determined that the above compiler exception only happens with projects using both the polyglot-kotlin extension and Kotlin 1.4.0. Upgrading the polyglot-kotlin extension to use Kotlin 1.4.0 fixes this issue.