### PR TITLE
Fixes #220

### DIFF
--- a/polyglot-common/src/main/java/org/sonatype/maven/polyglot/TeslaModelProcessor.java
+++ b/polyglot-common/src/main/java/org/sonatype/maven/polyglot/TeslaModelProcessor.java
@@ -72,8 +72,8 @@ public class TeslaModelProcessor implements ModelProcessor {
     }
     File polyglotPomFile = new File(pomFile.getParentFile(), POM_FILE_PREFIX + pomFile.getName());
     try {
-      if (polyglotPomFile.createNewFile()) {
-      polyglotPomFile.deleteOnExit();
+      if (!polyglotPomFile.exists() && polyglotPomFile.createNewFile()) {
+        polyglotPomFile.deleteOnExit();
       }
     } catch (IOException e) {
       throw new RuntimeException("error creating empty file", e);

--- a/polyglot-common/src/main/java/org/sonatype/maven/polyglot/TeslaProjectBuilder.java
+++ b/polyglot-common/src/main/java/org/sonatype/maven/polyglot/TeslaProjectBuilder.java
@@ -6,6 +6,7 @@ import java.util.stream.Collectors;
 
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.model.building.ModelProblem;
+import org.apache.maven.model.building.ModelProcessor;
 import org.apache.maven.model.building.ModelSource;
 import org.apache.maven.project.*;
 import org.codehaus.plexus.component.annotations.Component;
@@ -14,8 +15,8 @@ import org.codehaus.plexus.component.annotations.Requirement;
 @Component(role = ProjectBuilder.class)
 public class TeslaProjectBuilder extends DefaultProjectBuilder {
 
-    @Requirement
-    private TeslaModelProcessor modelProcessor;
+    @Requirement(role = ModelProcessor.class)
+    private TeslaModelProcessor teslaModelProcessor; // Must be named differently than the one in the superclass
 
     @Override
     public ProjectBuildingResult build(File pomFile, ProjectBuildingRequest request) throws ProjectBuildingException {
@@ -52,7 +53,7 @@ public class TeslaProjectBuilder extends DefaultProjectBuilder {
 
         // When running with the argument `-f <pomFile>`, we must restore the location of the generated pom xml file.
         // Otherwise, it retains a reference to the polyglot pom, which causes a `409 Conflict` error when deployed.
-        File pomFile = modelProcessor.getPomXmlFile(result.getPomFile()).orElse(result.getPomFile());
+        File pomFile = teslaModelProcessor.getPomXmlFile(result.getPomFile()).orElse(result.getPomFile());
         project.setPomFile(pomFile);
         project.getModel().setPomFile(pomFile);
 

--- a/polyglot-common/src/main/java/org/sonatype/maven/polyglot/TeslaProjectBuilder.java
+++ b/polyglot-common/src/main/java/org/sonatype/maven/polyglot/TeslaProjectBuilder.java
@@ -1,0 +1,107 @@
+package org.sonatype.maven.polyglot;
+
+import java.io.File;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.model.building.ModelProblem;
+import org.apache.maven.model.building.ModelSource;
+import org.apache.maven.project.*;
+import org.codehaus.plexus.component.annotations.Component;
+import org.codehaus.plexus.component.annotations.Requirement;
+
+@Component(role = ProjectBuilder.class)
+public class TeslaProjectBuilder extends DefaultProjectBuilder {
+
+    @Requirement
+    private TeslaModelProcessor modelProcessor;
+
+    @Override
+    public ProjectBuildingResult build(File pomFile, ProjectBuildingRequest request) throws ProjectBuildingException {
+        return convert(super.build(pomFile, request));
+    }
+
+    @Override
+    public ProjectBuildingResult build(ModelSource modelSource, ProjectBuildingRequest request) throws ProjectBuildingException {
+        return convert(super.build(modelSource, request));
+    }
+
+    @Override
+    public ProjectBuildingResult build(Artifact artifact, ProjectBuildingRequest request) throws ProjectBuildingException {
+        return convert(super.build(artifact, request));
+    }
+
+    @Override
+    public ProjectBuildingResult build(Artifact artifact, boolean allowStubModel, ProjectBuildingRequest request) throws ProjectBuildingException {
+        return convert(super.build(artifact, allowStubModel, request));
+    }
+
+    @Override
+    public List<ProjectBuildingResult> build(List<File> pomFiles, boolean recursive, ProjectBuildingRequest request) throws ProjectBuildingException {
+        List<ProjectBuildingResult> results = super.build(pomFiles, recursive, request);
+        return results.stream().map(this::convert).collect(Collectors.toList());
+    }
+
+    private ProjectBuildingResult convert(ProjectBuildingResult result) {
+        if (result.getPomFile() == null) return result;
+        String projectId = result.getProjectId();
+        MavenProject project = result.getProject();
+        List<ModelProblem> problems = result.getProblems();
+        DependencyResolutionResult dependencyResolutionResult = result.getDependencyResolutionResult();
+
+        // When running with the argument `-f <pomFile>`, we must restore the location of the generated pom xml file.
+        // Otherwise, it retains a reference to the polyglot pom, which causes a `409 Conflict` error when deployed.
+        File pomFile = modelProcessor.getPomXmlFile(result.getPomFile()).orElse(result.getPomFile());
+        project.setPomFile(pomFile);
+        project.getModel().setPomFile(pomFile);
+
+        return new TeslaProjectBuildingResult(projectId, pomFile, project, problems, dependencyResolutionResult);
+    }
+
+    private static class TeslaProjectBuildingResult implements ProjectBuildingResult {
+
+        private final String projectId;
+        private final File pomFile;
+        private final MavenProject project;
+        private final List<ModelProblem> problems;
+        private final DependencyResolutionResult dependencyResolutionResult;
+
+        public TeslaProjectBuildingResult(String projectId,
+                                          File pomFile,
+                                          MavenProject project,
+                                          List<ModelProblem> problems,
+                                          DependencyResolutionResult dependencyResolutionResult) {
+            this.projectId = projectId;
+            this.pomFile = pomFile;
+            this.project = project;
+            this.problems = problems;
+            this.dependencyResolutionResult = dependencyResolutionResult;
+        }
+
+        @Override
+        public String getProjectId() {
+            return projectId;
+        }
+
+        @Override
+        public File getPomFile() {
+            return pomFile;
+        }
+
+        @Override
+        public MavenProject getProject() {
+            return project;
+        }
+
+        @Override
+        public List<ModelProblem> getProblems() {
+            return problems;
+        }
+
+        @Override
+        public DependencyResolutionResult getDependencyResolutionResult() {
+            return dependencyResolutionResult;
+        }
+    }
+}

--- a/polyglot-kotlin/pom.xml
+++ b/polyglot-kotlin/pom.xml
@@ -64,7 +64,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <kotlin.version>1.4.0</kotlin.version>
+    <kotlin.version>1.4.10</kotlin.version>
     <commons-lang3.version>3.8.1</commons-lang3.version>
     <skipTests>false</skipTests>
     <invoker.skip>${skipTests}</invoker.skip>
@@ -75,6 +75,7 @@
     <testSourceDirectory>src/test/kotlin</testSourceDirectory>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-invoker-plugin</artifactId>
         <configuration>
           <failIfNoProjects>true</failIfNoProjects>
@@ -140,7 +141,7 @@
           <value>${project.version}</value>
         </configuration>
       </plugin>
-</plugins>
+    </plugins>
   </build>
 
 </project>


### PR DESCRIPTION
This fixes an issue that popped up on the Azure Pipelines Maven3 task. Azure Pipelines runs the build with the argument `-f path/to/pom/file`. When running with the `-f` argument, the logic for generating the file `.polyglot.pom.xxx` does not get invoked and the maven-depoy-plugin attempts to upload the polyglot pom script to the Maven repository instead, causing the build to fail with a `409 Conflict` error because the polyglot pom script is not valid xml.

This PR does the following:
1. Ensures that the xml pom file gets generated and written to `.polyglot.pom.xxx` whether running with the `-f` argument or not. The xml pom file is required for the maven install and deploy goals.
2. Adds a new `@Component` class named `TeslaProjectBuilder` to ensure that the location of the file `.polyglot.pom.xxx` gets set after the MavenProject object is produced. This ensures that the correct pom xml file will get copied into the local Maven repository for uploading to the remote Maven repository even when running with the `-f` argument.
