### PR TITLE
Bump maven-tools dependency

### DIFF
--- a/polyglot-ruby/pom.xml
+++ b/polyglot-ruby/pom.xml
@@ -138,7 +138,7 @@
         <dependency>
           <groupId>rubygems</groupId>
           <artifactId>maven-tools</artifactId>
-          <version>1.1.6</version>
+          <version>1.1.7</version>
           <type>gem</type>
           <scope>provided</scope>
         </dependency>


### PR DESCRIPTION
Follow up to #236.

`maven-tools` 1.1.7 has been released to rubygems.org, so we can now depend on it.

In https://github.com/takari/polyglot-maven/pull/236#issuecomment-957937107 I proposed a more flexible approach than relying on an exact dependency, but I'm still a maven newbie, so I guess I'll stick to the current approach for now.