### PR TITLE
Update jruby version because of CVE-2022-25857

### DIFF
--- a/polyglot-ruby/pom.xml
+++ b/polyglot-ruby/pom.xml
@@ -30,7 +30,7 @@
     <dependency>
       <groupId>org.jruby</groupId>
       <artifactId>jruby</artifactId>
-      <version>9.2.19.0</version>
+      <version>9.3.8.0</version>
       <type>pom</type>
     </dependency>
     <!-- Test -->


### PR DESCRIPTION
jruby < 9.3.8.0 include snakeyaml which comes with CVE-2022-25857