### PR TITLE
New Feature: Plugin lookup in execution contexts

### DIFF
--- a/polyglot-maven-plugin/src/main/java/org/sonatype/maven/polyglot/plugin/ExecuteMojo.java
+++ b/polyglot-maven-plugin/src/main/java/org/sonatype/maven/polyglot/plugin/ExecuteMojo.java
@@ -28,6 +28,7 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.PlexusContainer;
 import org.sonatype.maven.polyglot.PolyglotModelManager;
 import org.sonatype.maven.polyglot.execute.ExecuteContext;
 import org.sonatype.maven.polyglot.execute.ExecuteManager;
@@ -58,6 +59,9 @@ public class ExecuteMojo extends AbstractMojo {
 
   @Component(role = PolyglotModelManager.class)
   private PolyglotModelManager modelManager;
+
+  @Component
+  private PlexusContainer container;
 
   @Override
   public void execute() throws MojoExecutionException, MojoFailureException {
@@ -96,6 +100,10 @@ public class ExecuteMojo extends AbstractMojo {
       @Override
       public Log getLog() {
         return ExecuteMojo.this.getLog();
+      }
+      
+      public <T> T lookup(Class<T> clazz) {
+          return container.lookup(clazz);
       }
     };
 


### PR DESCRIPTION
As `execute` blocks in languages (specifically Ruby that I'm interested in) can't declare java `@Component` annotations to access other maven plugins, this feature would allow a target language to use a new method on the `ExecutionContex` to retreive instances from the IoC container.

Would need a bit of polish, but I'm gauging interest before I spend time finishing this. 