### PR TITLE
Update JRuby and all JRuby/Maven plugins

### DIFF
--- a/polyglot-ruby/pom.xml
+++ b/polyglot-ruby/pom.xml
@@ -151,7 +151,7 @@
         <dependency>
           <groupId>rubygems</groupId>
           <artifactId>maven-tools</artifactId>
-          <version>1.2.0.pre1</version>
+          <version>1.2.0</version>
           <type>gem</type>
           <scope>provided</scope>
         </dependency>

--- a/polyglot-ruby/pom.xml
+++ b/polyglot-ruby/pom.xml
@@ -30,7 +30,7 @@
     <dependency>
       <groupId>org.jruby</groupId>
       <artifactId>jruby</artifactId>
-      <version>9.2.19.0</version>
+      <version>9.4.3.0</version>
       <type>pom</type>
     </dependency>
     <!-- Test -->
@@ -43,13 +43,26 @@
   </dependencies>
 
   <properties>
-    <mavengem-wagon.version>1.0.3</mavengem-wagon.version>
+    <mavengem-wagon.version>2.0.0-SNAPSHOT</mavengem-wagon.version>
   </properties>
+
+  <pluginRepositories>
+    <pluginRepository>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+      <id>sonatype</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+    </pluginRepository>
+  </pluginRepositories>
 
   <build>
     <extensions>
       <extension>
-        <groupId>org.torquebox.mojo</groupId>
+        <groupId>org.jruby.maven</groupId>
         <artifactId>mavengem-wagon</artifactId>
         <version>${mavengem-wagon.version}</version>
       </extension>
@@ -87,7 +100,7 @@
               <pluginExecutions>
                 <pluginExecution>
                   <pluginExecutionFilter>
-                    <groupId>de.saumya.mojo</groupId>
+                    <groupId>org.jruby.maven</groupId>
                     <artifactId>
                       gem-maven-plugin
                     </artifactId>
@@ -138,21 +151,21 @@
         <dependency>
           <groupId>rubygems</groupId>
           <artifactId>maven-tools</artifactId>
-          <version>1.1.7</version>
+          <version>1.2.0.pre1</version>
           <type>gem</type>
           <scope>provided</scope>
         </dependency>
       </dependencies>
 
       <properties>
-        <jruby.plugins.version>2.0.1</jruby.plugins.version>
+        <jruby.plugins.version>3.0.0-SNAPSHOT</jruby.plugins.version>
       </properties>
 
       <build>
 
         <plugins>
           <plugin>
-            <groupId>de.saumya.mojo</groupId>
+            <groupId>org.jruby.maven</groupId>
             <artifactId>gem-maven-plugin</artifactId>
             <version>${jruby.plugins.version}</version>
             <executions>

--- a/polyglot-ruby/pom.xml
+++ b/polyglot-ruby/pom.xml
@@ -43,7 +43,7 @@
   </dependencies>
 
   <properties>
-    <mavengem-wagon.version>2.0.0</mavengem-wagon.version>
+    <mavengem-wagon.version>2.0.1</mavengem-wagon.version>
   </properties>
 
   <pluginRepositories>
@@ -151,14 +151,14 @@
         <dependency>
           <groupId>rubygems</groupId>
           <artifactId>maven-tools</artifactId>
-          <version>1.2.0</version>
+          <version>1.2.1</version>
           <type>gem</type>
           <scope>provided</scope>
         </dependency>
       </dependencies>
 
       <properties>
-        <jruby.plugins.version>3.0.0</jruby.plugins.version>
+        <jruby.plugins.version>3.0.1</jruby.plugins.version>
       </properties>
 
       <build>

--- a/polyglot-ruby/pom.xml
+++ b/polyglot-ruby/pom.xml
@@ -43,7 +43,7 @@
   </dependencies>
 
   <properties>
-    <mavengem-wagon.version>2.0.0-SNAPSHOT</mavengem-wagon.version>
+    <mavengem-wagon.version>2.0.0</mavengem-wagon.version>
   </properties>
 
   <pluginRepositories>
@@ -158,7 +158,7 @@
       </dependencies>
 
       <properties>
-        <jruby.plugins.version>3.0.0-SNAPSHOT</jruby.plugins.version>
+        <jruby.plugins.version>3.0.0</jruby.plugins.version>
       </properties>
 
       <build>

--- a/polyglot-ruby/src/test/java/org/sonatype/maven/polyglot/ruby/AbstractInjectedTestCase.java
+++ b/polyglot-ruby/src/test/java/org/sonatype/maven/polyglot/ruby/AbstractInjectedTestCase.java
@@ -199,7 +199,7 @@ public abstract class AbstractInjectedTestCase extends InjectedTestCase {
                 // the one from this plugin
                 .replaceAll("[0-9]+(-SNAPSHOT)?", VERSION_PATTERN)
 		// fix absolute path for test_pom_from_jarfile
-		.replaceAll("..basedir./myfirst.jar", "uri:classloader://myfirst.jar")
+		.replaceAll("..basedir./myfirst.jar", "uri:classloader:/myfirst.jar")
                 // some of the configuration tags are empty - unify them
                 .replaceAll("></(arg|chmod)>", "/>");
 	     if ( debug )

--- a/polyglot-ruby/src/test/poms/jruby-test-pom.xml
+++ b/polyglot-ruby/src/test/poms/jruby-test-pom.xml
@@ -157,7 +157,7 @@
     <defaultGoal>test</defaultGoal>
     <plugins>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
+        <groupId>org.jruby.maven</groupId>
         <artifactId>gem-maven-plugin</artifactId>
         <version>${jruby.plugins.version}</version>
         <inherited>false</inherited>


### PR DESCRIPTION
This is part of work to update the entire JRuby/Maven stack, in order to update the version of JRuby used and to address API deprecations at rubygems.org.

This PR updates JRuby to latest (9.4.3.0) and moves all plugins to their new org.jruby.maven group ID with latest versions.

Part of the fix for torquebox/maven-tools#37. (incorrectly tagged as #37 here before)

We will need to coordinate getting this released along with the maven plugins in the very near term. Because of the rubygems.org API being shut down next week (the 8th), we are under the gun.

See jruby/mavengem#9, jruby/jruby-maven-plugins#126, torquebox/maven-tools#38 and jruby/jruby#7872.