### PR TITLE
Update the JRuby/Maven stack

### DIFF
--- a/polyglot-ruby/pom.xml
+++ b/polyglot-ruby/pom.xml
@@ -30,7 +30,7 @@
     <dependency>
       <groupId>org.jruby</groupId>
       <artifactId>jruby</artifactId>
-      <version>9.4.3.0</version>
+      <version>9.4.5.0</version>
       <type>pom</type>
     </dependency>
     <!-- Test -->
@@ -43,7 +43,7 @@
   </dependencies>
 
   <properties>
-    <mavengem-wagon.version>2.0.1</mavengem-wagon.version>
+    <mavengem-wagon.version>2.0.2</mavengem-wagon.version>
   </properties>
 
   <pluginRepositories>
@@ -158,7 +158,7 @@
       </dependencies>
 
       <properties>
-        <jruby.plugins.version>3.0.1</jruby.plugins.version>
+        <jruby.plugins.version>3.0.2</jruby.plugins.version>
       </properties>
 
       <build>


### PR DESCRIPTION
* mavengem 2.0.2
* jruby-maven-plugins 3.0.2
* jruby 9.4.5.0

Various fixes have come to JRuby since 9.4.3.0 but this is mainly to eliminate a JPMS-related warning that prints at the beginning of any build using polyglot-ruby or the JRuby/Maven stack.

See https://github.com/jruby/jruby/pull/7970