### PR TITLE
Replace signing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,8 @@
     <mavenVersion>3.9.5</mavenVersion>
     <sisuInjectVersion>0.9.0.M2</sisuInjectVersion>
     <plexusUtilsVersion>3.5.1</plexusUtilsVersion>
+    <!-- last that works with Java 8: FIXED to this version as long we insist on Java 8 building this project -->
+    <!-- BUT: signArtifacts goal with this version is busted, so we need to use other means to sign -->
     <takari.lifecycleVersion>2.0.8</takari.lifecycleVersion>
     <takari.javaSourceVersion>8</takari.javaSourceVersion>
     <takari.transitiveDependencyReference>ignore</takari.transitiveDependencyReference>
@@ -259,4 +261,56 @@
       </plugins>
     </pluginManagement>
   </build>
+
+  <profiles>
+    <!-- START SNIPPET: release-profile -->
+    <profile>
+      <id>takari-release</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>3.1.0</version>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <!-- We use takari-lifecycle that works on Java8, and jpgp is busted in that version -->
+          <!-- We want to sign the artifact, the POM, and all attached artifacts -->
+          <plugin>
+            <groupId>io.takari.maven.plugins</groupId>
+            <artifactId>takari-lifecycle-plugin</artifactId>
+            <configuration>
+              <signArtifact>
+                <skip>true</skip>
+              </signArtifact>
+            </configuration>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>signArtifact</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <skip>true</skip>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <!-- END SNIPPET: release-profile -->
+  </profiles>
+
 </project>


### PR DESCRIPTION
We are forced to use takari-lifecycle 2.0.8 to support Java 8 building this project, but alas, signing using that version is busted.

Hence, we need to skip it, and provide alternate way using vanilla plugin, as Central requires signatures.

IMHO, this is okay compromise, as signing still happens in takari-release profile only.

Fixes #274.