### PR TITLE
Update Scala to 2.13.12

### DIFF
--- a/polyglot-scala/pom.xml
+++ b/polyglot-scala/pom.xml
@@ -45,7 +45,7 @@
     <dependency>
       <groupId>com.twitter</groupId>
       <artifactId>util-core_${scala.bin.version}</artifactId>
-      <version>6.43.0</version>
+      <version>22.3.0</version>
     </dependency>
 
     <dependency>

--- a/polyglot-scala/pom.xml
+++ b/polyglot-scala/pom.xml
@@ -20,8 +20,8 @@
   <name>Polyglot :: Scala</name>
   
   <properties>
-    <scala.version>2.12.18</scala.version>
-    <scala.bin.version>2.12</scala.bin.version>
+    <scala.version>2.13.12</scala.version>
+    <scala.bin.version>2.13</scala.bin.version>
   </properties>
 
   <contributors>
@@ -51,7 +51,7 @@
     <dependency>
       <groupId>org.scala-lang.modules</groupId>
       <artifactId>scala-xml_${scala.bin.version}</artifactId>
-      <version>1.0.6</version>
+      <version>2.2.0</version>
     </dependency>
 
     <dependency>

--- a/polyglot-scala/pom.xml
+++ b/polyglot-scala/pom.xml
@@ -55,9 +55,9 @@
     </dependency>
 
     <dependency>
-      <groupId>com.googlecode.kiama</groupId>
+      <groupId>org.bitbucket.inkytonik.kiama</groupId>
       <artifactId>kiama_${scala.bin.version}</artifactId>
-      <version>1.8.0</version>
+      <version>2.5.1</version>
     </dependency>
 
     <dependency>

--- a/polyglot-scala/pom.xml
+++ b/polyglot-scala/pom.xml
@@ -81,7 +81,7 @@
     <dependency>
       <groupId>org.specs2</groupId>
       <artifactId>specs2-junit_${scala.bin.version}</artifactId>
-      <version>3.9.5</version>
+      <version>4.20.2</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/polyglot-scala/src/it/java-and-scala-project-MavenModel/pom.scala
+++ b/polyglot-scala/src/it/java-and-scala-project-MavenModel/pom.scala
@@ -6,7 +6,7 @@ Model(
   name = "Test for Java + Scala compilation",
   description = "Test for Java + Scala compilation",
   dependencies = Seq(
-    "org.scala-lang" % "scala-library" % "2.12.18"
+    "org.scala-lang" % "scala-library" % "2.13.12"
   ),
   build = Build(
     pluginManagement = PluginManagement(

--- a/polyglot-scala/src/main/scala/org/sonatype/maven/polyglot/scala/ScalaModelReader.scala
+++ b/polyglot-scala/src/main/scala/org/sonatype/maven/polyglot/scala/ScalaModelReader.scala
@@ -275,7 +275,7 @@ class ScalaModelReader @Inject() (executeManager: ExecuteManager) extends ModelR
   }
 
   private def registerExecutors(m: Model, options: util.Map[String, _], tasks: immutable.Seq[Task]): Unit = {
-    import scala.collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
     executeManager.register(m, tasks.map(new ScalaTask(_).asInstanceOf[ExecuteTask]).asJava)
     executeManager.install(m, options)
   }

--- a/polyglot-scala/src/main/scala/org/sonatype/maven/polyglot/scala/ScalaModelWriter.scala
+++ b/polyglot-scala/src/main/scala/org/sonatype/maven/polyglot/scala/ScalaModelWriter.scala
@@ -10,7 +10,7 @@ package org.sonatype.maven.polyglot.scala
 import java.io.Writer
 import java.util
 import org.sonatype.maven.polyglot.io.ModelWriterSupport
-import org.kiama.output.PrettyPrinter
+import org.bitbucket.inkytonik.kiama.output.PrettyPrinter
 import org.apache.maven.model.{ Activation => MavenActivation, ActivationFile => MavenActivationFile, ActivationOS => MavenActivationOS, ActivationProperty => MavenActivationProperty, Build => MavenBuild, BuildBase => MavenBuildBase, CiManagement => MavenCiManagement, Contributor => MavenContributor, DependencyManagement => MavenDependencyManagement, Dependency => MavenDependency, DeploymentRepository => MavenDeploymentRepository, Developer => MavenDeveloper, DistributionManagement => MavenDistributionManagement, PluginExecution => MavenExecution, Extension => MavenExtension, IssueManagement => MavenIssueManagement, License => MavenLicense, MailingList => MavenMailingList, Model => MavenModel, Notifier => MavenNotifier, Organization => MavenOrganization, Parent => MavenParent, Plugin => MavenPlugin, PluginManagement => MavenPluginManagement, Prerequisites => MavenPrerequisites, Profile => MavenProfile, Relocation => MavenRelocation, RepositoryPolicy => MavenRepositoryPolicy, Repository => MavenRepository, Resource => MavenResource, Scm => MavenScm, Site => MavenSite, Reporting => MavenReporting, ReportPlugin => MavenReportPlugin, ReportSet => MavenReportSet }
 import org.sonatype.maven.polyglot.scala.model._
 import scala.collection.immutable
@@ -324,11 +324,11 @@ class ScalaModelWriter extends ModelWriterSupport {
 
     val d = "import" <+> "org.sonatype.maven.polyglot.scala.model._" <@>
       "import" <+> "scala.collection.immutable.Seq" <@>
-      empty <@>
+      emptyDoc <@>
       mm.asScala.asDoc <@>
-      empty
+      emptyDoc
     val pp = ScalaPrettyPrinter.pretty(d)
-    writer.append(pp)
+    writer.append(pp.layout)
     writer.flush()
   }
 

--- a/polyglot-scala/src/main/scala/org/sonatype/maven/polyglot/scala/ScalaModelWriter.scala
+++ b/polyglot-scala/src/main/scala/org/sonatype/maven/polyglot/scala/ScalaModelWriter.scala
@@ -42,7 +42,7 @@ object ScalaPrettyPrinter extends PrettyPrinter {
   }
 
   def mapStrings(m: Map[String, String]): Doc = {
-    "Map" <> lparen <> nest(lsep(m.map(me => dquotes(me._1) <+> "->" <+> dquotes(me._2)).to[immutable.Seq], comma)) <@> rparen
+    "Map" <> lparen <> nest(lsep(m.map(me => dquotes(me._1) <+> "->" <+> dquotes(me._2)).toSeq, comma)) <@> rparen
   }
 
   def seqString(s: immutable.Seq[String]): Doc = "Seq" <> lparen <> nest(lsep(s.map(dquotes(_)), comma)) <@> rparen

--- a/polyglot-scala/src/main/scala/org/sonatype/maven/polyglot/scala/eval/Eval.scala
+++ b/polyglot-scala/src/main/scala/org/sonatype/maven/polyglot/scala/eval/Eval.scala
@@ -464,7 +464,7 @@ class Eval(target: Option[File]) {
     val target = compilerOutputDir
 
     trait MessageCollector {
-      val messages: Seq[List[String]]
+      val messages: mutable.Seq[List[String]]
       val counts: Map[_root_.scala.reflect.internal.Reporter.Severity, AtomicInteger]
     }
 

--- a/polyglot-scala/src/main/scala/org/sonatype/maven/polyglot/scala/eval/Eval.scala
+++ b/polyglot-scala/src/main/scala/org/sonatype/maven/polyglot/scala/eval/Eval.scala
@@ -16,7 +16,7 @@
  */
 package org.sonatype.maven.polyglot.scala.eval
 
-import com.twitter.conversions.string._
+import com.twitter.conversions.StringOps._
 import com.twitter.io.StreamIO
 
 import java.io._
@@ -36,7 +36,7 @@ import scala.util.matching.Regex
 
 object Eval {
   private val jvmId = java.lang.Math.abs(new Random().nextInt())
-  val classCleaner: Regex = "\\W".r
+  private val classCleaner: Regex = "\\W".r
 
   class CompilerException(val messages: List[List[String]]) extends Exception(
     "Compiler exception " + messages.map(_.mkString("\n")).mkString("\n"))

--- a/polyglot-scala/src/main/scala/org/sonatype/maven/polyglot/scala/model/Build.scala
+++ b/polyglot-scala/src/main/scala/org/sonatype/maven/polyglot/scala/model/Build.scala
@@ -95,7 +95,7 @@ class PrettiedBuild(b: Build) {
 
 
 import org.sonatype.maven.polyglot.scala.MavenConverters._
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import org.apache.maven.model.{Build => MavenBuild}
 
 class ConvertibleMavenBuild(mb: MavenBuild) {

--- a/polyglot-scala/src/main/scala/org/sonatype/maven/polyglot/scala/model/BuildBase.scala
+++ b/polyglot-scala/src/main/scala/org/sonatype/maven/polyglot/scala/model/BuildBase.scala
@@ -71,7 +71,7 @@ class PrettiedBuildBase(b: BuildBase) {
 
 
 import org.sonatype.maven.polyglot.scala.MavenConverters._
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import org.apache.maven.model.{BuildBase => MavenBuildBase}
 
 class ConvertibleMavenBuildBase(mb: MavenBuildBase) {

--- a/polyglot-scala/src/main/scala/org/sonatype/maven/polyglot/scala/model/CiManagement.scala
+++ b/polyglot-scala/src/main/scala/org/sonatype/maven/polyglot/scala/model/CiManagement.scala
@@ -42,7 +42,7 @@ class PrettiedCiManagement(c: CiManagement) {
 
 
 import org.sonatype.maven.polyglot.scala.MavenConverters._
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import org.apache.maven.model.{CiManagement => MavenCiManagement}
 
 class ConvertibleMavenCiManagement(mcm: MavenCiManagement) {

--- a/polyglot-scala/src/main/scala/org/sonatype/maven/polyglot/scala/model/Config.scala
+++ b/polyglot-scala/src/main/scala/org/sonatype/maven/polyglot/scala/model/Config.scala
@@ -86,7 +86,7 @@ object Config extends Dynamic {
   def sanitizeElementName(k: String): String = {
     val r = elementStartCharMapping.foldLeft(k)((k, m) => m._1.replaceAllIn(k, found => m._2))
     if (r.length() > 1) {
-      r(0) + elementCharMapping.foldLeft(r.substring(1))((k, m) => m._1.replaceAllIn(k, found => m._2))
+      r.substring(0, 1) + elementCharMapping.foldLeft(r.substring(1))((k, m) => m._1.replaceAllIn(k, found => m._2))
     } else r
   }
 }

--- a/polyglot-scala/src/main/scala/org/sonatype/maven/polyglot/scala/model/Contributor.scala
+++ b/polyglot-scala/src/main/scala/org/sonatype/maven/polyglot/scala/model/Contributor.scala
@@ -60,7 +60,7 @@ class PrettiedContributor(c: Contributor) {
 }
 
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import org.apache.maven.model.{Contributor => MavenContributor}
 
 class ConvertibleMavenContributor(mc: MavenContributor) {

--- a/polyglot-scala/src/main/scala/org/sonatype/maven/polyglot/scala/model/Dependency.scala
+++ b/polyglot-scala/src/main/scala/org/sonatype/maven/polyglot/scala/model/Dependency.scala
@@ -91,8 +91,8 @@ class PrettiedDependency(d: Dependency) {
       `object`("Dependency", args.toList)
     } else {
       val gav = d.gav.asDoc
-      val version = if (d.gav.version.isEmpty) space <> percent <+> dquote <> dquote else empty
-      gav <> version <> d.scope.map(empty <+> percent <+> dquotes(_)).getOrElse(empty)
+      val version = if (d.gav.version.isEmpty) space <> percent <+> dquote <> dquote else emptyDoc
+      gav <> version <> d.scope.map(emptyDoc <+> percent <+> dquotes(_)).getOrElse(emptyDoc)
     }
   }
 }

--- a/polyglot-scala/src/main/scala/org/sonatype/maven/polyglot/scala/model/Dependency.scala
+++ b/polyglot-scala/src/main/scala/org/sonatype/maven/polyglot/scala/model/Dependency.scala
@@ -99,7 +99,7 @@ class PrettiedDependency(d: Dependency) {
 
 
 import org.sonatype.maven.polyglot.scala.MavenConverters._
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import org.apache.maven.model.{Dependency => MavenDependency, Exclusion => MavenExclusion}
 
 class ConvertibleMavenDependency(md: MavenDependency) {

--- a/polyglot-scala/src/main/scala/org/sonatype/maven/polyglot/scala/model/DependencyManagement.scala
+++ b/polyglot-scala/src/main/scala/org/sonatype/maven/polyglot/scala/model/DependencyManagement.scala
@@ -28,7 +28,7 @@ class PrettiedDependencyManagement(dm: DependencyManagement) {
 
 
 import org.sonatype.maven.polyglot.scala.MavenConverters._
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import org.apache.maven.model.{Dependency => MavenDependency, DependencyManagement => MavenDependencyManagement}
 
 class ConvertibleMavenDependencyManagement(mdm: MavenDependencyManagement) {

--- a/polyglot-scala/src/main/scala/org/sonatype/maven/polyglot/scala/model/Developer.scala
+++ b/polyglot-scala/src/main/scala/org/sonatype/maven/polyglot/scala/model/Developer.scala
@@ -40,7 +40,7 @@ object Developer {
              roles: immutable.Seq[String] = Nil,
              timezone: String = null,
              url: String = null
-             ) =
+             ): Developer =
     new Developer(
       Option(id),
       Option(email),
@@ -66,7 +66,7 @@ class PrettiedDeveloper(d: Developer) {
 }
 
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import org.apache.maven.model.{Developer => MavenDeveloper}
 
 class ConvertibleMavenDeveloper(mc: MavenDeveloper) {

--- a/polyglot-scala/src/main/scala/org/sonatype/maven/polyglot/scala/model/DistributionManagement.scala
+++ b/polyglot-scala/src/main/scala/org/sonatype/maven/polyglot/scala/model/DistributionManagement.scala
@@ -24,7 +24,7 @@ object DistributionManagement {
              downloadUrl: String = null,
              relocation: Relocation = null,
              status: String = null
-             ) =
+             ): DistributionManagement =
     new DistributionManagement(
       Option(repository),
       Option(snapshotRepository),

--- a/polyglot-scala/src/main/scala/org/sonatype/maven/polyglot/scala/model/Execution.scala
+++ b/polyglot-scala/src/main/scala/org/sonatype/maven/polyglot/scala/model/Execution.scala
@@ -24,7 +24,7 @@ object Execution {
              goals: immutable.Seq[String] = immutable.Seq.empty,
              inherited: Boolean = true,
              configuration: Config = null
-             ) = {
+             ): Execution = {
     new Execution(
       id,
       Option(phase),
@@ -51,7 +51,7 @@ class PrettiedExecution(e: Execution) {
 
 
 import org.sonatype.maven.polyglot.scala.MavenConverters._
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import org.apache.maven.model.{PluginExecution => MavenExecution}
 
 class ConvertibleMavenExecution(me: MavenExecution) {

--- a/polyglot-scala/src/main/scala/org/sonatype/maven/polyglot/scala/model/Gav.scala
+++ b/polyglot-scala/src/main/scala/org/sonatype/maven/polyglot/scala/model/Gav.scala
@@ -67,7 +67,7 @@ class PrettiedGroupArtifactId(ga: GroupArtifactId) {
 
 class PrettiedGav(gav: Gav) {
   def asDoc: Doc = {
-    dquotes(gav.groupId.getOrElse[String]("")) <+> percent <+> dquotes(gav.artifactId) <> gav.version.map(space <> percent <+> dquotes(_)).getOrElse(empty)
+    dquotes(gav.groupId.getOrElse[String]("")) <+> percent <+> dquotes(gav.artifactId) <> gav.version.map(space <> percent <+> dquotes(_)).getOrElse(emptyDoc)
   }
 }
 

--- a/polyglot-scala/src/main/scala/org/sonatype/maven/polyglot/scala/model/IssueManagement.scala
+++ b/polyglot-scala/src/main/scala/org/sonatype/maven/polyglot/scala/model/IssueManagement.scala
@@ -16,7 +16,7 @@ object IssueManagement {
   def apply(
              system: String = null,
              url: String = null
-             ) =
+             ): IssueManagement =
     new IssueManagement(
       Option(system),
       Option(url)

--- a/polyglot-scala/src/main/scala/org/sonatype/maven/polyglot/scala/model/License.scala
+++ b/polyglot-scala/src/main/scala/org/sonatype/maven/polyglot/scala/model/License.scala
@@ -20,7 +20,7 @@ object License {
              url: String = null,
              distribution: String = null,
              comments: String = null
-             ) =
+             ): License =
     new License(
       Option(name),
       Option(url),

--- a/polyglot-scala/src/main/scala/org/sonatype/maven/polyglot/scala/model/MailingList.scala
+++ b/polyglot-scala/src/main/scala/org/sonatype/maven/polyglot/scala/model/MailingList.scala
@@ -26,7 +26,7 @@ object MailingList {
              post: String = null,
              archive: String = null,
              otherArchives: immutable.Seq[String] = Nil
-             ) =
+             ): MailingList =
     new MailingList(
       Option(name),
       Option(subscribe),
@@ -54,7 +54,7 @@ class PrettiedMailingList(ml: MailingList) {
 
 
 import org.apache.maven.model.{MailingList => MavenMailingList}
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 class ConvertibleMavenMailingList(mml: MavenMailingList) {
   def asScala: MailingList = {

--- a/polyglot-scala/src/main/scala/org/sonatype/maven/polyglot/scala/model/Model.scala
+++ b/polyglot-scala/src/main/scala/org/sonatype/maven/polyglot/scala/model/Model.scala
@@ -177,7 +177,7 @@ class PrettiedModel(m: Model) {
 }
 
 import org.sonatype.maven.polyglot.scala.MavenConverters._
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import org.apache.maven.model.{ Model => MavenModel }
 
 class ConvertibleMavenModel(mm: MavenModel) {

--- a/polyglot-scala/src/main/scala/org/sonatype/maven/polyglot/scala/model/Notifier.scala
+++ b/polyglot-scala/src/main/scala/org/sonatype/maven/polyglot/scala/model/Notifier.scala
@@ -56,7 +56,7 @@ class PrettiedNotifier(n: Notifier) {
 }
 
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import org.apache.maven.model.{Notifier => MavenNotifier}
 
 class ConvertibleMavenNotifier(mn: MavenNotifier) {

--- a/polyglot-scala/src/main/scala/org/sonatype/maven/polyglot/scala/model/Organization.scala
+++ b/polyglot-scala/src/main/scala/org/sonatype/maven/polyglot/scala/model/Organization.scala
@@ -16,7 +16,7 @@ object Organization {
   def apply(
              name: String = null,
              url: String = null
-             ) =
+             ): Organization =
     new Organization(
       Option(name),
       Option(url)

--- a/polyglot-scala/src/main/scala/org/sonatype/maven/polyglot/scala/model/Parent.scala
+++ b/polyglot-scala/src/main/scala/org/sonatype/maven/polyglot/scala/model/Parent.scala
@@ -16,7 +16,7 @@ object Parent {
   def apply(
              gav: Gav = null,
              relativePath: String = "../pom.xml"
-             ) =
+             ): Parent =
     new Parent(
       Option(gav),
       relativePath

--- a/polyglot-scala/src/main/scala/org/sonatype/maven/polyglot/scala/model/Plugin.scala
+++ b/polyglot-scala/src/main/scala/org/sonatype/maven/polyglot/scala/model/Plugin.scala
@@ -26,7 +26,7 @@ object Plugin {
              dependencies: immutable.Seq[Dependency] = immutable.Seq.empty,
              inherited: Boolean = true,
              configuration: Config = null
-             ) =
+             ): Plugin =
     new Plugin(
       gav,
       extensions,
@@ -53,7 +53,7 @@ class PrettiedPlugin(p: Plugin) {
 
 
 import org.sonatype.maven.polyglot.scala.MavenConverters._
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 import org.apache.maven.model.{Plugin => MavenPlugin}
 

--- a/polyglot-scala/src/main/scala/org/sonatype/maven/polyglot/scala/model/PluginManagement.scala
+++ b/polyglot-scala/src/main/scala/org/sonatype/maven/polyglot/scala/model/PluginManagement.scala
@@ -27,7 +27,7 @@ class PrettiedPluginManagement(p: PluginManagement) {
 
 
 import org.sonatype.maven.polyglot.scala.MavenConverters._
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import org.apache.maven.model.{PluginManagement => MavenPluginManagement}
 
 class ConvertibleMavenPluginManagement(mpm: MavenPluginManagement) {

--- a/polyglot-scala/src/main/scala/org/sonatype/maven/polyglot/scala/model/Profile.scala
+++ b/polyglot-scala/src/main/scala/org/sonatype/maven/polyglot/scala/model/Profile.scala
@@ -41,7 +41,7 @@ object Profile {
              modules: immutable.Seq[String] = Nil,
              pluginRepositories: immutable.Seq[Repository] = Nil,
              repositories: immutable.Seq[Repository] = Nil
-             ) =
+             ): Profile =
     new Profile(
       id,
       Option(activation),
@@ -71,7 +71,7 @@ class PrettiedProfile(p: Profile) {
 
 
 import org.sonatype.maven.polyglot.scala.MavenConverters._
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import org.apache.maven.model.{Profile => MavenProfile}
 
 class ConvertibleMavenProfile(mp: MavenProfile) {

--- a/polyglot-scala/src/main/scala/org/sonatype/maven/polyglot/scala/model/Relocation.scala
+++ b/polyglot-scala/src/main/scala/org/sonatype/maven/polyglot/scala/model/Relocation.scala
@@ -20,7 +20,7 @@ object Relocation {
              artifactId: String = null,
              version: String = null,
              message: String = null
-             ) =
+             ): Relocation =
     new Relocation(
       Option(groupId),
       Option(artifactId),

--- a/polyglot-scala/src/main/scala/org/sonatype/maven/polyglot/scala/model/ReportPlugin.scala
+++ b/polyglot-scala/src/main/scala/org/sonatype/maven/polyglot/scala/model/ReportPlugin.scala
@@ -43,7 +43,7 @@ class PrettiedReportPlugin(p: ReportPlugin) {
 }
 
 import org.sonatype.maven.polyglot.scala.MavenConverters._
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 import org.apache.maven.model.{ ReportPlugin => MavenReportPlugin }
 

--- a/polyglot-scala/src/main/scala/org/sonatype/maven/polyglot/scala/model/ReportSet.scala
+++ b/polyglot-scala/src/main/scala/org/sonatype/maven/polyglot/scala/model/ReportSet.scala
@@ -43,7 +43,7 @@ class PrettiedReportSet(s: ReportSet) {
 }
 
 import org.sonatype.maven.polyglot.scala.MavenConverters._
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 import org.apache.maven.model.{ ReportSet => MavenReportSet }
 

--- a/polyglot-scala/src/main/scala/org/sonatype/maven/polyglot/scala/model/Reporting.scala
+++ b/polyglot-scala/src/main/scala/org/sonatype/maven/polyglot/scala/model/Reporting.scala
@@ -39,7 +39,7 @@ class PrettiedReporting(r: Reporting) {
 }
 
 import org.sonatype.maven.polyglot.scala.MavenConverters._
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import org.apache.maven.model.{ Reporting => MavenReporting }
 
 class ConvertibleMavenReporting(mr: MavenReporting) {

--- a/polyglot-scala/src/main/scala/org/sonatype/maven/polyglot/scala/model/Resource.scala
+++ b/polyglot-scala/src/main/scala/org/sonatype/maven/polyglot/scala/model/Resource.scala
@@ -24,7 +24,7 @@ object Resource {
              directory: String = null,
              includes: immutable.Seq[String] = Nil,
              excludes: immutable.Seq[String] = Nil
-             ) =
+             ): Resource =
     new Resource(
       Option(targetPath),
       filtering,
@@ -38,7 +38,7 @@ object Resource {
 import org.sonatype.maven.polyglot.scala.ScalaPrettyPrinter._
 
 class PrettiedResource(r: Resource) {
-  def asDoc = {
+  def asDoc: Doc = {
     val args = scala.collection.mutable.ListBuffer[Doc]()
     r.targetPath.foreach(args += assignString("targetPath", _))
     Some(r.filtering).filter(_ == true).foreach(f => args += assign("filtering", f.toString))
@@ -50,7 +50,7 @@ class PrettiedResource(r: Resource) {
 }
 
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import org.apache.maven.model.{Resource => MavenResource}
 
 class ConvertibleMavenResource(mr: MavenResource) {

--- a/polyglot-scala/src/main/scala/org/sonatype/maven/polyglot/scala/model/ScalaVersion.scala
+++ b/polyglot-scala/src/main/scala/org/sonatype/maven/polyglot/scala/model/ScalaVersion.scala
@@ -11,7 +11,7 @@ package org.sonatype.maven.polyglot.scala.model
  * A type to represent Scala versions
  */
 class ScalaVersion(val version: String) {
-  val binaryVersion = version.split("\\.", 3).take(2).mkString(".")
+  val binaryVersion: String = version.split("\\.", 3).take(2).mkString(".")
 }
 
 object ScalaVersion {

--- a/polyglot-scala/src/main/scala/org/sonatype/maven/polyglot/scala/model/Scm.scala
+++ b/polyglot-scala/src/main/scala/org/sonatype/maven/polyglot/scala/model/Scm.scala
@@ -20,7 +20,7 @@ object Scm {
              developerConnection: String = null,
              tag: String = "HEAD",
              url: String = null
-             ) =
+             ): Scm =
     new Scm(
       Option(connection),
       Option(developerConnection),

--- a/polyglot-scala/src/main/scala/org/sonatype/maven/polyglot/scala/model/Site.scala
+++ b/polyglot-scala/src/main/scala/org/sonatype/maven/polyglot/scala/model/Site.scala
@@ -18,7 +18,7 @@ object Site {
              id: String = null,
              name: String = null,
              url: String = null
-             ) =
+             ): Site =
     new Site(
       Option(id),
       Option(name),

--- a/polyglot-scala/src/main/scala/org/sonatype/maven/polyglot/scala/model/Task.scala
+++ b/polyglot-scala/src/main/scala/org/sonatype/maven/polyglot/scala/model/Task.scala
@@ -12,7 +12,7 @@ import org.sonatype.maven.polyglot.execute.ExecuteContext
 class Task(val id: String, val phase: String, val profileId: Option[String], val block: ExecuteContext => Unit)
 
 object Task {
-  def apply(id: String, phase: String, profileId: String = null)(block: ExecuteContext => Unit) =
+  def apply(id: String, phase: String, profileId: String = null)(block: ExecuteContext => Unit): Task =
     new Task(id, phase, Option(profileId), block)
 }
 

--- a/polyglot-scala/src/test/scala/org/sonatype/maven/polyglot/scala/DependencySpec.scala
+++ b/polyglot-scala/src/test/scala/org/sonatype/maven/polyglot/scala/DependencySpec.scala
@@ -19,26 +19,26 @@ class DependencySpec extends Specification {
     "be expressed in short form given a Gav" in {
       val dep = "somegroup" % "someartifact" % "someversion" % "test"
       dep.getClass.getSimpleName must_== "Dependency"
-      dep.gav.groupId must_== Some("somegroup")
+      dep.gav.groupId must beSome("somegroup")
       dep.gav.artifactId must_== "someartifact"
-      dep.gav.version must_== Some("someversion")
-      dep.scope must_== Some("test")
+      dep.gav.version must beSome("someversion")
+      dep.scope must beSome("test")
     }
     "be expressed in short form given just a Gav" in {
       val dep: Dependency = "somegroup" % "someartifact" % "someversion"
       dep.getClass.getSimpleName must_== "Dependency"
-      dep.gav.groupId must_== Some("somegroup")
+      dep.gav.groupId must beSome("somegroup")
       dep.gav.artifactId must_== "someartifact"
-      dep.gav.version must_== Some("someversion")
-      dep.scope must_== None
+      dep.gav.version must beSome("someversion")
+      dep.scope must beNone
     }
     "be expressed in short form given just a GroupArtifactId" in {
       val dep: Dependency = "somegroup" % "someartifact"
       dep.getClass.getSimpleName must_== "Dependency"
-      dep.gav.groupId must_== Some("somegroup")
+      dep.gav.groupId must beSome("somegroup")
       dep.gav.artifactId must_== "someartifact"
-      dep.gav.version must_== None
-      dep.scope must_== None
+      dep.gav.version must beNone
+      dep.scope must beNone
     }
   }
 }

--- a/polyglot-scala/src/test/scala/org/sonatype/maven/polyglot/scala/GavSpec.scala
+++ b/polyglot-scala/src/test/scala/org/sonatype/maven/polyglot/scala/GavSpec.scala
@@ -22,7 +22,7 @@ class GavSpec extends Specification {
       ga.groupId must_== Some("somegroup")
       ga.artifactId must_== "someartifact"
     }
-    "be expressed using the scala version convetion in the artifact" in {
+    "be expressed using the scala version convention in the artifact" in {
       implicit val scalaVersion = ScalaVersion("2.10.2")
       val ga = "somegroup" %% "someartifact"
       ga.getClass.getSimpleName must_== "GroupArtifactId"

--- a/polyglot-scala/src/test/scala/org/sonatype/maven/polyglot/scala/ScalaModelReaderWriterSpec.scala
+++ b/polyglot-scala/src/test/scala/org/sonatype/maven/polyglot/scala/ScalaModelReaderWriterSpec.scala
@@ -10,19 +10,24 @@ package org.sonatype.maven.polyglot.scala
 import org.specs2.mutable._
 import org.specs2.runner.JUnitRunner
 import org.junit.runner.RunWith
-import java.io.{StringWriter, InputStream, File}
-import scala.collection.JavaConverters._
-import org.apache.maven.model.building.{ ModelSource2, ModelProcessor }
+
+import java.io.{File, InputStream, StringWriter}
+import scala.jdk.CollectionConverters._
+import org.apache.maven.model.building.{ModelProcessor, ModelSource2}
 import org.specs2.specification.AfterEach
 import org.apache.maven.model.Model
 import org.codehaus.plexus.util.IOUtil
+
 import java.util.Collections
-import org.sonatype.maven.polyglot.execute.{ExecuteContext, ExecuteTask, ExecuteManager}
+import org.sonatype.maven.polyglot.execute.{ExecuteContext, ExecuteManager, ExecuteTask}
+
 import java.util
 import org.sonatype.maven.polyglot.scala.model.{Build => ScalaBuild, Model => ScalaRawModel, Task => ScalaModelTask}
+
 import scala.collection.{immutable, mutable}
 import org.apache.maven.project.MavenProject
 import org.apache.maven.execution.MavenSession
+import org.specs2.execute.Result
 
 @RunWith(classOf[JUnitRunner])
 class ScalaModelReaderWriterSpec extends Specification with AfterEach {
@@ -52,12 +57,12 @@ class ScalaModelReaderWriterSpec extends Specification with AfterEach {
       if (attributedTasks._1) attributedTasks._2 else List[ExecuteTask]().asJava
     }
 
-    override def install(model: Model, options: java.util.Map[String, _]) {
+    override def install(model: Model, options: java.util.Map[String, _]): Unit = {
       val attributedTasks = modelTasks.get(model).get
       modelTasks.put(model, (true, attributedTasks._2))
     }
 
-    def install(model: Model) {
+    def install(model: Model): Unit = {
       val attributedTasks = modelTasks.get(model).get
       modelTasks.put(model, (true, attributedTasks._2))
     }
@@ -91,7 +96,7 @@ class ScalaModelReaderWriterSpec extends Specification with AfterEach {
    *  Yet, the plugin still works, so I just disabled these tests and intend to
    *  add some maven-invoker-plugin based tests, to ensure, the built plugin still works.
    */
-  def withJava8(f: => org.specs2.execute.Result) = {
+  def withJava8(f: => org.specs2.execute.Result): Result = {
     if(sys.props("java.version").startsWith("1.")) {
       f
     } else {

--- a/polyglot-scala/src/test/scala/org/sonatype/maven/polyglot/scala/ScalaModelReaderWriterSpec.scala
+++ b/polyglot-scala/src/test/scala/org/sonatype/maven/polyglot/scala/ScalaModelReaderWriterSpec.scala
@@ -131,7 +131,7 @@ class ScalaModelReaderWriterSpec extends Specification with AfterEach {
         )
       )
 
-      val pp = ScalaPrettyPrinter.pretty(m.asDoc)
+      val pp = ScalaPrettyPrinter.pretty(m.asDoc).layout
 
       pp must_== """Model(
                    |  "someGroupId" % "someArtifactId" % "someVersion",
@@ -161,7 +161,7 @@ class ScalaModelReaderWriterSpec extends Specification with AfterEach {
         )
       )
 
-      val pp = ScalaPrettyPrinter.pretty(m.asDoc)
+      val pp = ScalaPrettyPrinter.pretty(m.asDoc).layout
 
       pp must_== """Model(
                    |  "someGroupId" % "someArtifactId" % "someVersion",
@@ -221,7 +221,7 @@ class ScalaModelReaderWriterSpec extends Specification with AfterEach {
         )
       )
 
-      val pp = ScalaPrettyPrinter.pretty(m.asDoc)
+      val pp = ScalaPrettyPrinter.pretty(m.asDoc).layout
 
       pp must_== """Model(
                    |  "someGroupId" % "someArtifactId" % "someVersion",

--- a/polyglot-scala/src/test/scala/org/sonatype/maven/polyglot/scala/ScalaModelSpec.scala
+++ b/polyglot-scala/src/test/scala/org/sonatype/maven/polyglot/scala/ScalaModelSpec.scala
@@ -29,7 +29,7 @@ class ScalaModelSpec extends Specification {
     sw.toString must_== IOUtil.toString(getClass.getClassLoader.getResourceAsStream(f))
   }
 
-  implicit val scalaVersion = ScalaVersion("2.10.2")
+  implicit val scalaVersion: ScalaVersion = ScalaVersion("2.10.2")
 
   "The ScalaModel" should {
     "configure a project with the minimal requirements" in {
@@ -58,18 +58,18 @@ class ScalaModelSpec extends Specification {
       )
 
       m.dependencies.size must_== 3
-      m.dependencies.head.gav.version must_== Some("0")
-      m.build.get.sourceDirectory must_== Some("src/main/scala2")
-      m.build.get.testSourceDirectory must_== Some("src/test/scala2")
+      m.dependencies.head.gav.version must beSome("0")
+      m.build.get.sourceDirectory must beSome("src/main/scala2")
+      m.build.get.testSourceDirectory must beSome("src/test/scala2")
       m.build.get.pluginManagement.get.plugins.size must_== 1
-      m.build.get.pluginManagement.get.plugins.head.gav.version must_== Some("0")
+      m.build.get.pluginManagement.get.plugins.head.gav.version must beSome("0")
       m.build.get.plugins.size must_== 3
       m.build.get.plugins.head.gav.artifactId must_== "maven-compiler-plugin"
-      m.build.get.plugins.head.gav.version must_== Some("0")
+      m.build.get.plugins.head.gav.version must beSome("0")
       m.build.get.plugins(1).gav.artifactId must_== "scala-maven-plugin"
-      m.build.get.plugins(1).gav.version must_== Some("0")
+      m.build.get.plugins(1).gav.version must beSome("0")
       m.build.get.plugins(2).gav.artifactId must_== "maven-surefire-plugin"
-      m.build.get.plugins(2).gav.version must_== Some("0")
+      m.build.get.plugins(2).gav.version must beSome("0")
     }
   }
 }


### PR DESCRIPTION
This PR updates from Scala 2.12 to 2.13. With the update to Scala 2.13.12, which is the latest available Scala 2.x version, `polyglot-scala` should also support Java 21.

I suggest to have this PR and PR https://github.com/takari/polyglot-maven/pull/277 (which updates from Scala 2.11 to 2.12) not in the same release, to give users of `polyglot-scala` a chance to migrate their builds step by step. But TBH, I have no clue how many users we still have.

Along this update, I bumped various dependencies, migrated some Scala syntax and fixed deprecated or removed API call sites. I also fixed some issues with left-open file resources.

