### PR TITLE
Move to latest parent and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,27 +7,7 @@ on:
   pull_request:
 
 jobs:
-  setup:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Stop old builds
-        if: github.ref != 'refs/heads/master'
-        uses: styfle/cancel-workflow-action@0.11.0
-        with:
-          access_token: ${{ github.token }}
-
   build:
-    needs: setup
-    strategy:
-      matrix:
-        java: [ 8, 11, 17 ]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: "Set up JDK ${{ matrix.java }}"
-        uses: actions/setup-java@v3
-        with:
-          java-version: ${{ matrix.java }}
-          distribution: 'temurin'
-      - name: Build & Test
-        run: ./mvnw -B verify
+    name: Verify
+    uses: takari/takari-gh-actions/.github/workflows/ci.yml@v2
+

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>io.takari</groupId>
     <artifactId>takari</artifactId>
-    <version>51</version>
+    <version>52</version>
   </parent>
 
   <groupId>io.takari.polyglot</groupId>
@@ -31,9 +31,6 @@
     <mavenVersion>3.9.5</mavenVersion>
     <sisuInjectVersion>0.9.0.M2</sisuInjectVersion>
     <plexusUtilsVersion>3.5.1</plexusUtilsVersion>
-    <!-- last that works with Java 8: FIXED to this version as long we insist on Java 8 building this project -->
-    <!-- BUT: signArtifacts goal with this version is busted, so we need to use other means to sign -->
-    <takari.lifecycleVersion>2.0.8</takari.lifecycleVersion>
     <takari.javaSourceVersion>8</takari.javaSourceVersion>
     <takari.transitiveDependencyReference>ignore</takari.transitiveDependencyReference>
   </properties>
@@ -261,56 +258,4 @@
       </plugins>
     </pluginManagement>
   </build>
-
-  <profiles>
-    <!-- START SNIPPET: release-profile -->
-    <profile>
-      <id>takari-release</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-gpg-plugin</artifactId>
-            <version>3.1.0</version>
-            <executions>
-              <execution>
-                <id>sign-artifacts</id>
-                <phase>verify</phase>
-                <goals>
-                  <goal>sign</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-          <!-- We use takari-lifecycle that works on Java8, and jpgp is busted in that version -->
-          <!-- We want to sign the artifact, the POM, and all attached artifacts -->
-          <plugin>
-            <groupId>io.takari.maven.plugins</groupId>
-            <artifactId>takari-lifecycle-plugin</artifactId>
-            <configuration>
-              <signArtifact>
-                <skip>true</skip>
-              </signArtifact>
-            </configuration>
-            <executions>
-              <execution>
-                <goals>
-                  <goal>signArtifact</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <configuration>
-              <skip>true</skip>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <!-- END SNIPPET: release-profile -->
-  </profiles>
-
 </project>


### PR DESCRIPTION
And remove signign workaround: lifecycle 2.1.2 is fixed to work with Java8 bytecode, and this makes signing working again.

Also, move to latest CI GH action that now allows
"tuning" JDK versions and uses proper concurrency
instead of the deprecated action to cancel jobs.