### PR TITLE
Fix for polyglot when in lib/ext

### DIFF
--- a/polyglot-common/src/main/java/org/sonatype/maven/polyglot/TeslaModelProcessor.java
+++ b/polyglot-common/src/main/java/org/sonatype/maven/polyglot/TeslaModelProcessor.java
@@ -32,6 +32,7 @@ import org.apache.maven.model.io.ModelReader;
 import org.apache.maven.model.io.xpp3.MavenXpp3Writer;
 import org.codehaus.plexus.util.FileUtils;
 import org.codehaus.plexus.util.IOUtil;
+import org.eclipse.sisu.Priority;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.codehaus.plexus.util.ReaderFactory;
@@ -46,6 +47,7 @@ import org.codehaus.plexus.util.ReaderFactory;
 //@Component(role = ModelProcessor.class, hint = "tesla-polyglot")
 @Singleton
 @Named
+@Priority(10)
 public class TeslaModelProcessor implements ModelProcessor {
 
   private static final String DEFAULT_POM_FILE = "pom.xml";

--- a/polyglot-common/src/main/java/org/sonatype/maven/polyglot/TeslaProjectBuilder.java
+++ b/polyglot-common/src/main/java/org/sonatype/maven/polyglot/TeslaProjectBuilder.java
@@ -14,37 +14,46 @@ import org.apache.maven.model.building.ModelSource;
 import org.apache.maven.project.*;
 import org.eclipse.sisu.Priority;
 
+import static java.util.Objects.requireNonNull;
+
 @Singleton
 @Named
 @Priority(10)
-public class TeslaProjectBuilder extends DefaultProjectBuilder {
+public class TeslaProjectBuilder implements ProjectBuilder {
+
+    private final TeslaModelProcessor teslaModelProcessor; // Must be named differently than the one in the superclass
+
+    private final DefaultProjectBuilder defaultProjectBuilder;
 
     @Inject
-    private TeslaModelProcessor teslaModelProcessor; // Must be named differently than the one in the superclass
+    public TeslaProjectBuilder(TeslaModelProcessor teslaModelProcessor, DefaultProjectBuilder defaultProjectBuilder) {
+        this.teslaModelProcessor = requireNonNull(teslaModelProcessor);
+        this.defaultProjectBuilder = requireNonNull(defaultProjectBuilder);
+    }
 
     @Override
     public ProjectBuildingResult build(File pomFile, ProjectBuildingRequest request) throws ProjectBuildingException {
-        return convert(super.build(pomFile, request));
+        return convert(defaultProjectBuilder.build(pomFile, request));
     }
 
     @Override
     public ProjectBuildingResult build(ModelSource modelSource, ProjectBuildingRequest request) throws ProjectBuildingException {
-        return convert(super.build(modelSource, request));
+        return convert(defaultProjectBuilder.build(modelSource, request));
     }
 
     @Override
     public ProjectBuildingResult build(Artifact artifact, ProjectBuildingRequest request) throws ProjectBuildingException {
-        return convert(super.build(artifact, request));
+        return convert(defaultProjectBuilder.build(artifact, request));
     }
 
     @Override
     public ProjectBuildingResult build(Artifact artifact, boolean allowStubModel, ProjectBuildingRequest request) throws ProjectBuildingException {
-        return convert(super.build(artifact, allowStubModel, request));
+        return convert(defaultProjectBuilder.build(artifact, allowStubModel, request));
     }
 
     @Override
     public List<ProjectBuildingResult> build(List<File> pomFiles, boolean recursive, ProjectBuildingRequest request) throws ProjectBuildingException {
-        List<ProjectBuildingResult> results = super.build(pomFiles, recursive, request);
+        List<ProjectBuildingResult> results = defaultProjectBuilder.build(pomFiles, recursive, request);
         return results.stream().map(this::convert).collect(Collectors.toList());
     }
 

--- a/polyglot-common/src/main/java/org/sonatype/maven/polyglot/TeslaProjectBuilder.java
+++ b/polyglot-common/src/main/java/org/sonatype/maven/polyglot/TeslaProjectBuilder.java
@@ -21,7 +21,7 @@ import static java.util.Objects.requireNonNull;
 @Priority(10)
 public class TeslaProjectBuilder implements ProjectBuilder {
 
-    private final TeslaModelProcessor teslaModelProcessor; // Must be named differently than the one in the superclass
+    private final TeslaModelProcessor teslaModelProcessor;
 
     private final DefaultProjectBuilder defaultProjectBuilder;
 

--- a/polyglot-common/src/main/java/org/sonatype/maven/polyglot/TeslaProjectBuilder.java
+++ b/polyglot-common/src/main/java/org/sonatype/maven/polyglot/TeslaProjectBuilder.java
@@ -12,9 +12,11 @@ import org.apache.maven.artifact.Artifact;
 import org.apache.maven.model.building.ModelProblem;
 import org.apache.maven.model.building.ModelSource;
 import org.apache.maven.project.*;
+import org.eclipse.sisu.Priority;
 
 @Singleton
 @Named
+@Priority(10)
 public class TeslaProjectBuilder extends DefaultProjectBuilder {
 
     @Inject


### PR DESCRIPTION
Originally polyglot worked when loaded via .mvn/extensions.xml but not when created custom distro (put in lib/ext).

Reason was simple, as Maven core beans were not overridden when in "flat space", that causes lib/ext, unlike mvn extensions.

To make it work from lib/ext (when components are placed into maven core), following is needed:
* DefaultProjectBuilder is "default" bean, hence we need to override it (using priority)
* DefaultModelProcessor is trickier, it uses custom name (despite class name being Default) and uses Typed annotation. Essentially same thing, using priority makes polyglot component "prevail" as otherwise they are same ranked (non-default custom named components).
* finally, do not extend component but use JSR330 capability to inject "exact" bean and just compose (possible as all used methods are public on replaced bean as well).