### PR TITLE
Parent 64 update

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,7 @@
+# Transitional config until reformat happens
+# Spotless: reformat of sources must happen (ideally in later ignored-blame commit)
+# Modernizer: warns of deprecated constructs for targeted Java lang level
+-D
+spotless.skip
+-D
+modernizer.skip

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,6 +1,3 @@
-# Transitional config until reformat happens
-# Spotless: reformat of sources must happen (ideally in later ignored-blame commit)
-# Modernizer: warns of deprecated constructs for targeted Java lang level
 -D
 spotless.skip
 -D

--- a/README.md
+++ b/README.md
@@ -59,8 +59,13 @@ end
 
 # Requirements
 
+Runtime (when used in some project):
 * [Maven](http://maven.apache.org) 3.6.3+
 * [Java](http://java.sun.com/) 8+
+
+Build time (of this project):
+* Maven 3.9+
+* Java 17+
 
 # Usage
 

--- a/its/polyglot-atom/pom.xml
+++ b/its/polyglot-atom/pom.xml
@@ -26,6 +26,10 @@
       <groupId>io.takari.polyglot</groupId>
       <artifactId>polyglot-atom</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.takari.polyglot</groupId>
+      <artifactId>polyglot-maven-plugin</artifactId>
+    </dependency>
   </dependencies>
 
 </project>

--- a/its/polyglot-atom/pom.xml
+++ b/its/polyglot-atom/pom.xml
@@ -19,6 +19,7 @@
   </parent>
 
   <artifactId>polyglot-atom</artifactId>
+  <name>Polyglot :: Atom ITs</name>
 
   <dependencies>
     <dependency>

--- a/its/polyglot-clojure/pom.xml
+++ b/its/polyglot-clojure/pom.xml
@@ -19,6 +19,7 @@
   </parent>
 
   <artifactId>polyglot-clojure</artifactId>
+  <name>Polyglot :: Clojure ITs</name>
 
   <dependencies>  
     <dependency>

--- a/its/polyglot-clojure/pom.xml
+++ b/its/polyglot-clojure/pom.xml
@@ -26,5 +26,9 @@
       <groupId>io.takari.polyglot</groupId>
       <artifactId>polyglot-clojure</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.takari.polyglot</groupId>
+      <artifactId>polyglot-maven-plugin</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/its/polyglot-groovy/pom.xml
+++ b/its/polyglot-groovy/pom.xml
@@ -14,6 +14,7 @@
   </parent>
 
   <artifactId>polyglot-groovy</artifactId>
+  <name>Polyglot :: Groovy ITs</name>
 
   <properties>
     <groovy.compiler.version>2.9.2-01</groovy.compiler.version>

--- a/its/polyglot-groovy/pom.xml
+++ b/its/polyglot-groovy/pom.xml
@@ -26,5 +26,9 @@
       <groupId>io.takari.polyglot</groupId>
       <artifactId>polyglot-groovy</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.takari.polyglot</groupId>
+      <artifactId>polyglot-maven-plugin</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/its/polyglot-java/pom.xml
+++ b/its/polyglot-java/pom.xml
@@ -21,6 +21,10 @@
       <groupId>io.takari.polyglot</groupId>
       <artifactId>polyglot-java</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.takari.polyglot</groupId>
+      <artifactId>polyglot-maven-plugin</artifactId>
+    </dependency>
   </dependencies>
 
 </project>

--- a/its/polyglot-java/pom.xml
+++ b/its/polyglot-java/pom.xml
@@ -14,6 +14,7 @@
   </parent>
 
   <artifactId>polyglot-java</artifactId>
+  <name>Polyglot :: Java ITs</name>
 
   <dependencies>
     <dependency>

--- a/its/polyglot-kotlin/pom.xml
+++ b/its/polyglot-kotlin/pom.xml
@@ -26,6 +26,10 @@
       <groupId>io.takari.polyglot</groupId>
       <artifactId>polyglot-kotlin</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.takari.polyglot</groupId>
+      <artifactId>polyglot-maven-plugin</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/its/polyglot-kotlin/pom.xml
+++ b/its/polyglot-kotlin/pom.xml
@@ -19,6 +19,8 @@
   </parent>
 
   <artifactId>polyglot-kotlin</artifactId>
+  <name>Polyglot :: Kotlin ITs</name>
+
   <dependencies>
     <dependency>
       <groupId>io.takari.polyglot</groupId>

--- a/its/polyglot-kotlin/src/it/jar-project/.mvn/extensions.xml
+++ b/its/polyglot-kotlin/src/it/jar-project/.mvn/extensions.xml
@@ -2,8 +2,8 @@
 <extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.0.0 http://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
   <extension>
-    <groupId>@project.groupId@</groupId>
-    <artifactId>@project.artifactId@</artifactId>
+    <groupId>io.takari.polyglot</groupId>
+    <artifactId>polyglot-kotlin</artifactId>
     <version>@project.version@</version>
   </extension>
 </extensions>

--- a/its/polyglot-maven-plugin/pom.xml
+++ b/its/polyglot-maven-plugin/pom.xml
@@ -14,5 +14,6 @@
   </parent>
 
   <artifactId>polyglot-maven-plugin</artifactId>
+  <name>Polyglot :: Maven Plugin ITs</name>
 
 </project>

--- a/its/polyglot-maven-plugin/pom.xml
+++ b/its/polyglot-maven-plugin/pom.xml
@@ -16,4 +16,11 @@
   <artifactId>polyglot-maven-plugin</artifactId>
   <name>Polyglot :: Maven Plugin ITs</name>
 
+  <dependencies>
+    <dependency>
+      <groupId>io.takari.polyglot</groupId>
+      <artifactId>polyglot-maven-plugin</artifactId>
+    </dependency>
+  </dependencies>
+
 </project>

--- a/its/polyglot-ruby/pom.xml
+++ b/its/polyglot-ruby/pom.xml
@@ -19,6 +19,7 @@
   </parent>
 
   <artifactId>polyglot-ruby</artifactId>
+  <name>Polyglot :: Ruby ITs</name>
 
   <dependencies>
     <dependency>

--- a/its/polyglot-ruby/pom.xml
+++ b/its/polyglot-ruby/pom.xml
@@ -26,6 +26,10 @@
       <groupId>io.takari.polyglot</groupId>
       <artifactId>polyglot-ruby</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.takari.polyglot</groupId>
+      <artifactId>polyglot-maven-plugin</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/its/polyglot-ruby/src/it/use_jruby_installation/verify.bsh
+++ b/its/polyglot-ruby/src/it/use_jruby_installation/verify.bsh
@@ -3,7 +3,7 @@ import org.codehaus.plexus.util.FileUtils;
 
 
 String log = FileUtils.fileRead( new File( basedir, "build.log" ) );
-String expected = "jruby version 9.4.5.0";
+String expected = "jruby version 9.4.12.0";
 if ( !log.contains( expected ) )
 {
     throw new RuntimeException( "log file does not contain '" + expected + "'" );

--- a/its/polyglot-scala/pom.xml
+++ b/its/polyglot-scala/pom.xml
@@ -24,6 +24,10 @@
       <groupId>io.takari.polyglot</groupId>
       <artifactId>polyglot-scala</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.takari.polyglot</groupId>
+      <artifactId>polyglot-maven-plugin</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/its/polyglot-scala/pom.xml
+++ b/its/polyglot-scala/pom.xml
@@ -15,7 +15,9 @@
     <artifactId>its</artifactId>
     <version>0.7.3-SNAPSHOT</version>
   </parent>
+
   <artifactId>polyglot-scala</artifactId>
+  <name>Polyglot :: Scala ITs</name>
 
   <dependencies>
     <dependency>

--- a/its/polyglot-scala/src/it/java-and-scala-project-MavenModel/.mvn/extensions.xml
+++ b/its/polyglot-scala/src/it/java-and-scala-project-MavenModel/.mvn/extensions.xml
@@ -2,8 +2,8 @@
 <extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.0.0 http://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
   <extension>
-    <groupId>@project.groupId@</groupId>
-    <artifactId>@project.artifactId@</artifactId>
+    <groupId>io.takari.polyglot</groupId>
+    <artifactId>polyglot-scala</artifactId>
     <version>@project.version@</version>
   </extension>
 </extensions>

--- a/its/polyglot-translate-plugin/pom.xml
+++ b/its/polyglot-translate-plugin/pom.xml
@@ -16,4 +16,14 @@
   <artifactId>polyglot-translate-plugin</artifactId>
   <name>Polyglot :: Translate Plugin ITs</name>
 
+  <dependencies>
+    <dependency>
+      <groupId>io.takari.polyglot</groupId>
+      <artifactId>polyglot-translate-plugin</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.takari.polyglot</groupId>
+      <artifactId>polyglot-maven-plugin</artifactId>
+    </dependency>
+  </dependencies>
 </project>

--- a/its/polyglot-translate-plugin/pom.xml
+++ b/its/polyglot-translate-plugin/pom.xml
@@ -14,5 +14,6 @@
   </parent>
 
   <artifactId>polyglot-translate-plugin</artifactId>
+  <name>Polyglot :: Translate Plugin ITs</name>
 
 </project>

--- a/its/polyglot-xml/pom.xml
+++ b/its/polyglot-xml/pom.xml
@@ -11,7 +11,9 @@
 		<artifactId>its</artifactId>
 		<version>0.7.3-SNAPSHOT</version>
 	</parent>
+
 	<artifactId>polyglot-xml</artifactId>
+	<name>Polyglot :: XML ITs</name>
 
 	<dependencies>
 		<dependency>

--- a/its/polyglot-xml/pom.xml
+++ b/its/polyglot-xml/pom.xml
@@ -20,5 +20,9 @@
 			<groupId>io.takari.polyglot</groupId>
 			<artifactId>polyglot-xml</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>io.takari.polyglot</groupId>
+			<artifactId>polyglot-maven-plugin</artifactId>
+		</dependency>
 	</dependencies>
 </project>

--- a/its/polyglot-yaml/pom.xml
+++ b/its/polyglot-yaml/pom.xml
@@ -25,5 +25,9 @@
       <groupId>io.takari.polyglot</groupId>
       <artifactId>polyglot-yaml</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.takari.polyglot</groupId>
+      <artifactId>polyglot-maven-plugin</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/its/polyglot-yaml/pom.xml
+++ b/its/polyglot-yaml/pom.xml
@@ -16,7 +16,9 @@
     <artifactId>its</artifactId>
     <version>0.7.3-SNAPSHOT</version>
   </parent>
+
   <artifactId>polyglot-yaml</artifactId>
+  <name>Polyglot :: Yaml ITs</name>
 
   <dependencies>
     <dependency>

--- a/its/pom.xml
+++ b/its/pom.xml
@@ -51,6 +51,24 @@
       <properties>
         <invoker.skip>false</invoker.skip>
       </properties>
+      <build>
+        <plugins>
+          <!-- Kill spotless during IT: ITs may run on Java 8 -->
+          <plugin>
+            <groupId>com.diffplug.spotless</groupId>
+            <artifactId>spotless-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>check</id>
+                <goals>
+                  <goal>check</goal>
+                </goals>
+                <phase>none</phase>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
   </profiles>
 </project>

--- a/its/pom.xml
+++ b/its/pom.xml
@@ -59,7 +59,7 @@
             <artifactId>spotless-maven-plugin</artifactId>
             <executions>
               <execution>
-                <id>check</id>
+                <id>default</id>
                 <goals>
                   <goal>check</goal>
                 </goals>

--- a/polyglot-clojure/pom.xml
+++ b/polyglot-clojure/pom.xml
@@ -30,7 +30,7 @@
     <dependency>
       <groupId>org.clojure</groupId>
       <artifactId>clojure</artifactId>
-      <version>1.11.4</version>
+      <version>1.12.0</version>
     </dependency>    
     <dependency>
       <groupId>org.easytesting</groupId>
@@ -45,7 +45,7 @@
       <plugin>
         <groupId>com.theoryinpractise</groupId>
         <artifactId>clojure-maven-plugin</artifactId>
-        <version>1.9.2</version>
+        <version>1.9.3</version>
         <executions>
           <execution>
             <goals>

--- a/polyglot-groovy/pom.xml
+++ b/polyglot-groovy/pom.xml
@@ -62,7 +62,7 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>3.25.3</version>
+      <version>3.27.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/polyglot-java/pom.xml
+++ b/polyglot-java/pom.xml
@@ -31,18 +31,18 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.15.0</version>
+      <version>2.19.0</version>
     </dependency>
     <dependency>
       <groupId>commons-beanutils</groupId>
       <artifactId>commons-beanutils</artifactId>
-      <version>1.9.4</version>
+      <version>1.10.1</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.cedarsoftware</groupId>
       <artifactId>java-util</artifactId>
-      <version>1.68.0</version>
+      <version>3.3.1</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/polyglot-kotlin/pom.xml
+++ b/polyglot-kotlin/pom.xml
@@ -62,7 +62,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-text</artifactId>
-      <version>1.12.0</version>
+      <version>1.13.1</version>
     </dependency>
 
     <!-- Test -->
@@ -80,7 +80,7 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>3.25.3</version>
+      <version>3.27.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -92,7 +92,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <kotlin.version>2.0.20</kotlin.version>
+    <kotlin.version>2.1.20</kotlin.version>
     <commons-lang3.version>3.8.1</commons-lang3.version>
     <skipTests>false</skipTests>
     <invoker.skip>${skipTests}</invoker.skip>

--- a/polyglot-ruby/pom.xml
+++ b/polyglot-ruby/pom.xml
@@ -30,7 +30,7 @@
     <dependency>
       <groupId>org.jruby</groupId>
       <artifactId>jruby</artifactId>
-      <version>9.4.5.0</version>
+      <version>9.4.12.0</version>
       <type>pom</type>
     </dependency>
     <!-- Test -->
@@ -130,14 +130,14 @@
         <dependency>
           <groupId>rubygems</groupId>
           <artifactId>maven-tools</artifactId>
-          <version>1.2.1</version>
+          <version>1.2.2</version>
           <type>gem</type>
           <scope>provided</scope>
         </dependency>
       </dependencies>
 
       <properties>
-        <jruby.plugins.version>3.0.3</jruby.plugins.version>
+        <jruby.plugins.version>3.0.5</jruby.plugins.version>
       </properties>
 
       <build>

--- a/polyglot-scala/pom.xml
+++ b/polyglot-scala/pom.xml
@@ -20,7 +20,7 @@
   <name>Polyglot :: Scala</name>
   
   <properties>
-    <scala.version>2.13.15</scala.version>
+    <scala.version>2.13.16</scala.version>
     <scala.bin.version>2.13</scala.bin.version>
   </properties>
 
@@ -81,7 +81,7 @@
     <dependency>
       <groupId>org.specs2</groupId>
       <artifactId>specs2-junit_${scala.bin.version}</artifactId>
-      <version>4.20.2</version>
+      <version>4.21.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -103,7 +103,7 @@
       <plugin>
         <groupId>net.alchim31.maven</groupId>
         <artifactId>scala-maven-plugin</artifactId>
-        <version>4.9.2</version>
+        <version>4.9.5</version>
         <executions>
           <execution>
             <goals>

--- a/polyglot-xml/pom.xml
+++ b/polyglot-xml/pom.xml
@@ -23,7 +23,7 @@
 		<dependency>
 			<groupId>com.cedarsoftware</groupId>
 			<artifactId>java-util</artifactId>
-			<version>1.68.0</version>
+			<version>3.3.1</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/polyglot-yaml/pom.xml
+++ b/polyglot-yaml/pom.xml
@@ -28,7 +28,7 @@
     <dependency>
       <groupId>org.yaml</groupId>
       <artifactId>snakeyaml</artifactId>
-      <version>2.2</version>
+      <version>2.4</version>
     </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -229,6 +229,24 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>com.diffplug.spotless</groupId>
+        <artifactId>spotless-maven-plugin</artifactId>
+        <configuration>
+          <scala>
+            <scalafmt />
+          </scala>
+          <groovy>
+            <importOrder />
+            <removeSemicolons />
+            <!-- Not using greclipse; pulls in whole Eclipse -->
+            <!--greclipse /-->
+          </groovy>
+          <kotlin>
+            <ktfmt />
+          </kotlin>
+        </configuration>
+      </plugin>
     </plugins>
     <pluginManagement>
       <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>io.takari</groupId>
     <artifactId>takari</artifactId>
-    <version>51</version>
+    <version>64</version>
   </parent>
 
   <groupId>io.takari.polyglot</groupId>
@@ -229,7 +229,7 @@
       <plugins>
         <plugin>
           <artifactId>maven-invoker-plugin</artifactId>
-          <version>3.8.0</version>
+          <version>3.9.0</version>
           <configuration>
             <scope>test</scope>
             <postBuildHookScript>verify</postBuildHookScript>
@@ -302,7 +302,6 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>3.2.5</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>

--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,11 @@
       </dependency>
       <dependency>
         <groupId>io.takari.polyglot</groupId>
+        <artifactId>polyglot-translate-plugin</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.takari.polyglot</groupId>
         <artifactId>polyglot-ruby</artifactId>
         <version>${project.version}</version>
       </dependency>


### PR DESCRIPTION
Update to latest Takari parent and stack. This raised build time requirement of this project to Java 17+. Project still produces Java 8 bytecode and ITs run on range of Java version from 8 to 24 (all LTS).

Important: latest Takari parent brings in Spotless and Modernizer, and both report issues (and would fail the build), hence they are right now **disabled**. To fix:
* spotless needs _reformatting of codebase_.
* modernizer reports code construct issues, so needs code changes

This PR now pushes tooling to latest. Also, previous PRs applied required CI changes, so we now build all artifacts on Java 21 / Maven 3.9.9 combo, and next we test built artifacts in matrix of OS/Java/Maven (check GH CI) by running ITs.

It also contains "mild updates" across the modules, please take a peek.

IF this PR gets merged, then:
* it will be followed by a reformat "no code change" commit + git-blame ignore. Spotless configuration updated.
* modernizer fixes